### PR TITLE
Adding new methods to KeyStore.cryptsl

### DIFF
--- a/bin/de/darmstadt/tu/crossing/KeyStore.cryptsl
+++ b/bin/de/darmstadt/tu/crossing/KeyStore.cryptsl
@@ -7,6 +7,7 @@ OBJECTS
     char[] passwordKey;
     
     byte[] entry;
+    byte[] byteKey;
     
     java.security.KeyStore.LoadStoreParameter paramLoad;
     java.security.KeyStore.ProtectionParameter protParamGet;
@@ -16,6 +17,8 @@ OBJECTS
     java.io.OutputStream fileoutput;
     java.security.KeyStore.LoadStoreParameter paramStore;
     java.lang.String keyStoreAlg;
+    java.security.cert.Certificate[] chain;
+    java.security.cert.Certificate cert;
     
     java.security.Key key;
     java.lang.String alias;
@@ -35,8 +38,11 @@ EVENTS
 
     gE: getEntry(aliasGet, protParamGet);
     sE: setEntry(aliasSet, entry, protParamSet);
+    scE: setCertificateEntry(alias, cert);
+    skE1: setKeyEntry(alias, byteKey, chain);
+    skE2: setKeyEntry(alias, key, passwordKey, chain);
     
-    Entries := gE | sE;
+    Entries := gE | sE | scE | skE1 | skE2;
     
     gk: key = getKey(alias, passwordKey);
 

--- a/src/de/darmstadt/tu/crossing/KeyStore.cryptsl
+++ b/src/de/darmstadt/tu/crossing/KeyStore.cryptsl
@@ -7,6 +7,7 @@ OBJECTS
     char[] passwordKey;
     
     byte[] entry;
+    byte[] byteKey;
     
     java.security.KeyStore.LoadStoreParameter paramLoad;
     java.security.KeyStore.ProtectionParameter protParamGet;
@@ -16,6 +17,8 @@ OBJECTS
     java.io.OutputStream fileoutput;
     java.security.KeyStore.LoadStoreParameter paramStore;
     java.lang.String keyStoreAlg;
+    java.security.cert.Certificate[] chain;
+    java.security.cert.Certificate cert;
     
     java.security.Key key;
     java.lang.String alias;
@@ -35,8 +38,11 @@ EVENTS
 
     gE: getEntry(aliasGet, protParamGet);
     sE: setEntry(aliasSet, entry, protParamSet);
+    scE: setCertificateEntry(alias, cert);
+    skE1: setKeyEntry(alias, byteKey, chain);
+    skE2: setKeyEntry(alias, key, passwordKey, chain);
     
-    Entries := gE | sE;
+    Entries := gE | sE | scE | skE1 | skE2;
     
     gk: key = getKey(alias, passwordKey);
 


### PR DESCRIPTION
setKeyEntry and setCertificateEntry are added to cryptsl as detailed in issue #83