### PR TITLE
Tink

### DIFF
--- a/src/de/darmstadt/tu/crossing/tink/AeadFactory.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/AeadFactory.cryptsl
@@ -15,7 +15,7 @@ ORDER
 	gp
 
 REQUIRES 
-	generatedKeysetHandle[ksh]; 
+	generatedKeySet[ksh]; 
 	
 ENSURES
-	setAeadPrimitive[aead];
+	aeadPrimitive[aead];

--- a/src/de/darmstadt/tu/crossing/tink/AeadKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/AeadKeyTemplates.cryptsl
@@ -25,36 +25,31 @@ SPEC com.google.crypto.tink.aead.AeadKeyTemplates
 OBJECTS
 	com.google.crypto.tink.proto.KeyTemplate kt;
 	
-	int k16;
-	int k32; 
+	int key;
+	int iv; 
 	
 	com.google.crypto.tink.proto.HashType hashType;  // HashType enum: (1) - SHA1, (3) - SHA256, and (4) - SHA 512. 
 	
 EVENTS
-	aes128_gcm_evt : kt = createAesGcmKeyTemplate(k16);
-	aes256_gcm_evt : kt = createAesGcmKeyTemplate(k32);
-	aes128_eax_evt : kt = createAesEaxKeyTemplate(k16, k16);
-	aes256_eax_evt : kt = createAesEaxKeyTemplate(k32, k16);
+	aes_gcm_evt : kt = createAesGcmKeyTemplate(key);
+	aes_eax_evt : kt = createAesEaxKeyTemplate(key, iv);
 
 //	aes128_ctr_hmac_sha256_evt : aes128_ctr_hmac_sha256 = createAesCtrHmacAeadKeyTemplate(k16, iv16, hmk32, tag16, hashType);
 //	aes256_ctr_hmac_sha256_evt : aes256_ctr_hmac_sha256 = createAesCtrHmacAeadKeyTemplate(k16, iv16, hmk32, tag32, hashType);
 	
-	CreateKeyTemplates := aes128_gcm_evt | aes256_gcm_evt | aes128_eax_evt | aes256_eax_evt;// | aes128_ctr_hmac_sha256_evt | aes256_ctr_hmac_sha256_evt ;
+	CreateKeyTemplates := aes_gcm_evt | aes_eax_evt;// | aes128_ctr_hmac_sha256_evt | aes256_ctr_hmac_sha256_evt ;
 	
 ORDER 
 	(CreateKeyTemplates)+	
 
 CONSTRAINTS
-	k16 == 16;
-	k32 == 32; 
+	key in {16, 32};
+	iv == 16; 
 	 
 	//hashType == com.google.crypto.tink.proto.HashType.HashTyp.SHA256; 
 	
 ENSURES
-	keyTemplate[kt] after aes128_gcm_evt;
-	keyTemplate[kt] after aes256_gcm_evt;
-	keyTemplate[kt] after aes128_eax_evt;
-	keyTemplate[kt] after aes256_eax_evt;
+	keyTemplate[kt];
 
 //	keyTemplate[aes128_ctr_hmac_sha256] after aes128_ctr_hmac_sha256_evt;
 //	keyTemplate[aes256_ctr_hmac_sha256] after aes256_ctr_hmac_sha256_evt;

--- a/src/de/darmstadt/tu/crossing/tink/AeadKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/AeadKeyTemplates.cryptsl
@@ -44,7 +44,7 @@ ORDER
 
 CONSTRAINTS
 	key in {16, 32};
-	iv == 16; 
+	iv in {16}; 
 	 
 	//hashType == com.google.crypto.tink.proto.HashType.HashTyp.SHA256; 
 	

--- a/src/de/darmstadt/tu/crossing/tink/AeadPrimitive.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/AeadPrimitive.cryptsl
@@ -5,8 +5,6 @@
 SPEC com.google.crypto.tink.Aead
 
 OBJECTS
-	com.google.crypto.tink.Aead aead; 
-	
 	byte[] plainText;
 	byte[] cipherText;
 	byte[] aad;
@@ -21,7 +19,7 @@ ORDER
 	(Mode)*
 
 REQUIRES 
-	setAeadPrimitive[aead];
+	aeadPrimitive[this];
 	
 ENSURES
 	encrypted[cipherText, plainText];

--- a/src/de/darmstadt/tu/crossing/tink/DeterministicAead.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/DeterministicAead.cryptsl
@@ -1,0 +1,25 @@
+/*
+ * A CrySL specification for using the Deterministic AEAD Ciphers (Authenticated 
+ * Encryption with Associated Data) of the Google Tink library. 
+ */
+SPEC com.google.crypto.tink.DeterministicAead
+
+OBJECTS
+	byte[] plainText;
+	byte[] cipherText;
+	byte[] aad;
+
+EVENTS
+	enc : cipherText = encryptDeterministically(plainText, aad);
+	dec : plainText = decryptDeterministically(cipherText, aad); 
+	
+	Mode := enc | dec; 
+
+ORDER
+	(Mode)*
+
+REQUIRES 
+	daeadPrimitive[this];
+	
+ENSURES
+	encrypted[cipherText];

--- a/src/de/darmstadt/tu/crossing/tink/DeterministicAeadFactory.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/DeterministicAeadFactory.cryptsl
@@ -1,0 +1,21 @@
+/*
+ * A CrySL specification for using the Deterministic AEAD Factory 
+ * of the Google Google library. 
+ */
+SPEC com.google.crypto.tink.daead.DeterministicAeadFactory
+
+OBJECTS
+	com.google.crypto.tink.KeysetHandle ksh;
+	com.google.crypto.tink.DeterministicAead daead; 
+
+EVENTS
+	gp : daead = getPrimitive(ksh);
+
+ORDER
+	gp
+
+REQUIRES 
+	generatedKeySet[ksh]; 
+	
+ENSURES
+	daeadPrimitive[daead];

--- a/src/de/darmstadt/tu/crossing/tink/DeterministicAeadKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/DeterministicAeadKeyTemplates.cryptsl
@@ -24,13 +24,11 @@ OBJECTS
 EVENTS
     aes256_siv_evt : aes256_siv = createAesSivKeyTemplate(k64);
 	
-	CreateKeyTemplates := aes256_siv_evt;
-	
 ORDER 
-	(CreateKeyTemplates)*	
+	aes256_siv_evt*	
 
 CONSTRAINTS
-	k64 == 64;
+	k64 in {64};
 	
 ENSURES
 	keyTemplate[aes256_siv];

--- a/src/de/darmstadt/tu/crossing/tink/DeterministicAeadKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/DeterministicAeadKeyTemplates.cryptsl
@@ -1,0 +1,37 @@
+/*
+ * This is a CrySL specification for the Google Tink implementation of 
+ * the class DeterministicAeadKeyTemplates. 
+ * 
+ * Note: in this case, we are not specifying the correct usage of the 
+ * API, but actually guaranteeing that the Google Tink API implementation 
+ * actually exposes some key templates as static attributes. This 
+ * information simplifies the specification of other properties for 
+ * correctly using the API. 
+ * 
+ * 
+ * It constraints the use of the API to the following key templates: 
+ * 
+ * - aes256_siv
+ */
+
+SPEC com.google.crypto.tink.daead.DeterministicAeadKeyTemplates
+
+OBJECTS
+	com.google.crypto.tink.proto.KeyTemplate aes256_siv;
+	
+	int k64;
+	
+EVENTS
+    aes256_siv_evt : aes256_siv = createAesSivKeyTemplate(k64);
+	
+	CreateKeyTemplates := aes256_siv_evt;
+	
+ORDER 
+	(CreateKeyTemplates)*	
+
+CONSTRAINTS
+	k64 == 64;
+	
+ENSURES
+	keyTemplate[aes256_siv];
+	

--- a/src/de/darmstadt/tu/crossing/tink/HybridDecrypt.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/HybridDecrypt.cryptsl
@@ -1,0 +1,21 @@
+/*
+ * A CrySL specification for using the Hybrid Encryption modes 
+ * of the Google Tink library. 
+ */
+ SPEC com.google.crypto.tink.HybridDecrypt
+
+OBJECTS
+	byte[] plainText;
+	byte[] cipherText;
+	byte[] context;
+
+EVENTS
+	dec : plainText = decrypt(cipherText, context);
+	
+	Mode := dec ; 
+
+ORDER
+	(Mode)*
+
+REQUIRES 
+	hybridDecryptPrimitive[this];

--- a/src/de/darmstadt/tu/crossing/tink/HybridDecrypt.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/HybridDecrypt.cryptsl
@@ -11,11 +11,9 @@ OBJECTS
 
 EVENTS
 	dec : plainText = decrypt(cipherText, context);
-	
-	Mode := dec ; 
 
 ORDER
-	(Mode)*
+	dec*
 
 REQUIRES 
 	hybridDecryptPrimitive[this];

--- a/src/de/darmstadt/tu/crossing/tink/HybridDecryptFactory.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/HybridDecryptFactory.cryptsl
@@ -1,0 +1,22 @@
+/*
+ * A CrySL specification for using the Deterministic AEAD Factory 
+ * of the Google Google library. 
+ */
+ 
+ SPEC com.google.crypto.tink.hybrid.HybridDecryptFactory
+
+OBJECTS
+	com.google.crypto.tink.KeysetHandle ksh;
+	com.google.crypto.tink.HybridDecrypt hybridAlgorithm; 
+
+EVENTS
+	gp : hybridAlgorithm = getPrimitive(ksh);
+
+ORDER
+	gp
+
+REQUIRES 
+	generatedKeySet[ksh]; 
+	
+ENSURES
+	hybridDecryptPrimitive[hybridAlgorithm];

--- a/src/de/darmstadt/tu/crossing/tink/HybridEncrypt.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/HybridEncrypt.cryptsl
@@ -12,11 +12,9 @@ OBJECTS
 
 EVENTS
 	enc : cipherText = encrypt(plainText, context);
-	
-	Mode := enc ; 
-
+		
 ORDER
-	(Mode)*
+	enc*
 
 REQUIRES 
 	hybridEncriptPrimitive[this];

--- a/src/de/darmstadt/tu/crossing/tink/HybridEncrypt.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/HybridEncrypt.cryptsl
@@ -1,0 +1,25 @@
+/*
+ * A CrySL specification for using the Hybrid Decryption modes 
+ * of the Google Tink library. 
+ */
+
+SPEC com.google.crypto.tink.HybridEncrypt
+
+OBJECTS
+	byte[] plainText;
+	byte[] cipherText;
+	byte[] context;
+
+EVENTS
+	enc : cipherText = encrypt(plainText, context);
+	
+	Mode := enc ; 
+
+ORDER
+	(Mode)*
+
+REQUIRES 
+	hybridEncriptPrimitive[this];
+	
+ENSURES
+	encrypted[cipherText];

--- a/src/de/darmstadt/tu/crossing/tink/HybridEncryptFactory.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/HybridEncryptFactory.cryptsl
@@ -1,0 +1,22 @@
+/*
+ * A CrySL specification for using the Deterministic AEAD Factory 
+ * of the Google Google library. 
+ */
+
+SPEC com.google.crypto.tink.hybrid.HybridEncryptFactory
+
+OBJECTS
+	com.google.crypto.tink.KeysetHandle ksh;
+	com.google.crypto.tink.HybridEncrypt hybridAlgorithm; 
+
+EVENTS
+	gp : hybridAlgorithm = getPrimitive(ksh);
+
+ORDER
+	gp
+
+REQUIRES 
+	generatedPublicKeySet[ksh]; 
+	
+ENSURES
+	hybridEncriptPrimitive[hybridAlgorithm];

--- a/src/de/darmstadt/tu/crossing/tink/HybridKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/HybridKeyTemplates.cryptsl
@@ -23,7 +23,7 @@ OBJECTS
 				
 EVENTS
    	ecies_aes128_gcm_evt: ecies_aes128_gcm = createEciesAeadHkdfKeyTemplate(_, _, _, _, _);
-	ecies_aes128_ctr_hmac_evt : ecies_aes128_ctr_hmac = createEciesAeadHkdfKeyTemplate(_, _, _, _, _);
+	ecies_aes128_ctr_hmac_evt: ecies_aes128_ctr_hmac = createEciesAeadHkdfKeyTemplate(_, _, _, _, _);
 	
 	CreateKeyTemplates := ecies_aes128_gcm_evt | ecies_aes128_ctr_hmac_evt;
 	

--- a/src/de/darmstadt/tu/crossing/tink/HybridKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/HybridKeyTemplates.cryptsl
@@ -1,0 +1,38 @@
+/*
+ * This is a CrySL specification for the Google Tink implementation of 
+ * the class HybridKeyTemplates. 
+ * 
+ * Note: in this case, we are not specifying the correct usage of the 
+ * API, but actually guaranteeing that the Google Tink API implementation 
+ * actually exposes some key templates as static attributes. This 
+ * information simplifies the specification of other properties for 
+ * correctly using the API. 
+ * 
+ * 
+ * It constraints the use of the API to the following key templates: 
+ * 
+ * - ecies_aes128_gcm
+ * - ecies_aes128_ctr_hmac
+ */
+
+SPEC com.google.crypto.tink.hybrid.HybridKeyTemplates
+
+OBJECTS
+	com.google.crypto.tink.proto.KeyTemplate ecies_aes128_gcm; 
+	com.google.crypto.tink.proto.KeyTemplate ecies_aes128_ctr_hmac; 
+				
+EVENTS
+   	ecies_aes128_gcm_evt: ecies_aes128_gcm = createEciesAeadHkdfKeyTemplate(_, _, _, _, _);
+	ecies_aes128_ctr_hmac_evt : ecies_aes128_ctr_hmac = createEciesAeadHkdfKeyTemplate(_, _, _, _, _);
+	
+	CreateKeyTemplates := ecies_aes128_gcm_evt | ecies_aes128_ctr_hmac_evt;
+	
+ORDER 
+	(CreateKeyTemplates)*	
+
+	
+ENSURES
+	keyTemplate[ecies_aes128_gcm];
+	keyTemplate[ecies_aes128_ctr_hmac];
+	
+	

--- a/src/de/darmstadt/tu/crossing/tink/KeysetHandle.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/KeysetHandle.cryptsl
@@ -18,7 +18,6 @@ EVENTS
     read_evt       : read(_, _); 
     export_evt     : write(_, _); 
     
-    
 ORDER
     (gen_evt | read_evt), gen_public_evt?, export_evt?  
    

--- a/src/de/darmstadt/tu/crossing/tink/KeysetHandle.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/KeysetHandle.cryptsl
@@ -10,14 +10,17 @@ SPEC com.google.crypto.tink.KeysetHandle
 
 OBJECTS
     com.google.crypto.tink.proto.KeyTemplate kt;
+    com.google.crypto.tink.KeysetHandle publicKeysetHandle; 
 
 EVENTS
-    gen_evt    : generateNew(kt);
-    read_evt   : read(_, _); 
-    export_evt : write(_, _); 
+    gen_evt        : generateNew(kt);
+    gen_public_evt : publicKeysetHandle = getPublicKeysetHandle();
+    read_evt       : read(_, _); 
+    export_evt     : write(_, _); 
+    
     
 ORDER
-    (gen_evt | read_evt), export_evt?  
+    (gen_evt | read_evt), gen_public_evt?, export_evt?  
    
 
 REQUIRES
@@ -25,3 +28,4 @@ REQUIRES
 	
 ENSURES
 	generatedKeySet[this];
+	generatedPublicKeySet[publicKeysetHandle];

--- a/src/de/darmstadt/tu/crossing/tink/MacFactory.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/MacFactory.cryptsl
@@ -15,7 +15,7 @@ ORDER
 	gp
 
 REQUIRES 
-	generatedKeysetHandle[ksh]; 
+	generatedKeySet[ksh]; 
 	
 ENSURES
-	generateMacPrimitive[mac];
+	macPrimitive[mac];

--- a/src/de/darmstadt/tu/crossing/tink/MacKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/MacKeyTemplates.cryptsl
@@ -27,10 +27,8 @@ OBJECTS
 EVENTS
 	hmac_sha256_evt : hmac_sha256 = createHmacKeyTemplate(key, tag, _);
 	
-	CreateKeyTemplates := hmac_sha256_evt;
-	
 ORDER 
-	(CreateKeyTemplates)
+	(hmac_sha256_evt)
 
 CONSTRAINTS
 	key == 32;

--- a/src/de/darmstadt/tu/crossing/tink/MacKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/MacKeyTemplates.cryptsl
@@ -17,31 +17,26 @@
 SPEC com.google.crypto.tink.mac.MacKeyTemplates
 
 OBJECTS
-	com.google.crypto.tink.proto.KeyTemplate hmac_sha256_128bittag;
-	com.google.crypto.tink.proto.KeyTemplate hmac_sha256_256bittag;
+	com.google.crypto.tink.proto.KeyTemplate hmac_sha256;
 	
-	int k16;
-	int k32; 
+	int key;
+	int tag; 
 	
 	int hashType;  // HashType enum: (1) - SHA1, (3) - SHA256, and (4) - SHA 512. 
 	
 EVENTS
-	hmac_sha256_128bittag_evt : hmac_sha256_128bittag = createHmacKeyTemplate(k32, k16, _);
-	hmac_sha256_256bittag_evt : hmac_sha256_256bittag = createHmacKeyTemplate(k32, k32, _);
+	hmac_sha256_evt : hmac_sha256 = createHmacKeyTemplate(key, tag, _);
 	
-	
-	CreateKeyTemplates := hmac_sha256_128bittag_evt | hmac_sha256_256bittag_evt;
+	CreateKeyTemplates := hmac_sha256_evt;
 	
 ORDER 
 	(CreateKeyTemplates)
 
 CONSTRAINTS
-	k16 == 16;
-	k32 == 32; 
+	key == 32;
+	tag in {16, 32};
 	
 	//hashType == 3; 
 	
-	
 ENSURES
-	macKeyTemplate[hmac_sha256_128bittag] after hmac_sha256_128bittag_evt;
-	macKeyTemplate[hmac_sha256_256bittag] after hmac_sha256_256bittag_evt;
+	keyTemplate[hmac_sha256];

--- a/src/de/darmstadt/tu/crossing/tink/MacPrimitive.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/MacPrimitive.cryptsl
@@ -5,8 +5,6 @@
 SPEC com.google.crypto.tink.Mac
 
 OBJECTS
-	com.google.crypto.tink.Mac mac; 
-	
 	byte[] data;
 	byte[] tag;
 
@@ -20,7 +18,7 @@ ORDER
 	(Mode)*
 
 REQUIRES 
-	generateMacPrimitive[mac];
+	macPrimitive[this];
 	
 ENSURES
 	generateMacFromData[tag, data];

--- a/src/de/darmstadt/tu/crossing/tink/PublicKeySign.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/PublicKeySign.cryptsl
@@ -1,0 +1,18 @@
+/*
+ * A CrySL specification for using the Public Signature algorithms of the Google 
+ * Tink library. 
+ */
+SPEC com.google.crypto.tink.PublicKeySign
+
+OBJECTS
+	byte[] data;
+	byte[] signature;
+
+EVENTS
+	sign_evt : 	signature = sign(data);
+	
+ORDER
+	sign_evt+	
+
+REQUIRES
+	publicKeySignaturePrimitive[this];

--- a/src/de/darmstadt/tu/crossing/tink/PublicKeySignFactory.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/PublicKeySignFactory.cryptsl
@@ -1,0 +1,23 @@
+/*
+ * A CrySL specification for using the Public Key Signature Factory 
+ * of the Google Google library. 
+ */
+ 
+SPEC com.google.crypto.tink.signature.PublicKeySignFactory
+
+OBJECTS 
+	com.google.crypto.tink.KeysetHandle ksh;
+	com.google.crypto.tink.PublicKeySign pks;
+
+EVENTS
+	gp : pks = getPrimitive(ksh);
+
+ORDER 
+	gp+
+	
+REQUIRES 
+	generatedKeySet[ksh]; 
+	
+ENSURES
+	publicKeySignaturePrimitive[pks];	
+			

--- a/src/de/darmstadt/tu/crossing/tink/PublicKeyVerify.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/PublicKeyVerify.cryptsl
@@ -1,0 +1,18 @@
+/*
+ * A CrySL specification for using the Public Signature Verification algorithms of the Google 
+ * Tink library. 
+ */
+SPEC com.google.crypto.tink.PublicKeyVerify
+
+OBJECTS
+	byte[] data;
+	byte[] signature;
+
+EVENTS
+	verify_evt : verify(signature, data);
+	
+ORDER
+	verify_evt+	
+
+REQUIRES
+	publicKeyVerifyPrimitive[this];

--- a/src/de/darmstadt/tu/crossing/tink/PublicKeyVerifyFactory.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/PublicKeyVerifyFactory.cryptsl
@@ -1,0 +1,23 @@
+/*
+ * A CrySL specification for using the Public Key Signature Factory 
+ * of the Google Google library. 
+ */
+ 
+SPEC com.google.crypto.tink.signature.PublicKeyVerifyFactory
+
+OBJECTS 
+	com.google.crypto.tink.KeysetHandle ksh;
+	com.google.crypto.tink.PublicKeyVerify pkv;
+
+EVENTS
+	gp : pkv = getPrimitive(ksh);
+
+ORDER 
+	gp+
+	
+REQUIRES 
+	generatedPublicKeySet[ksh]; 
+	
+ENSURES
+	publicKeyVerifyPrimitive[pkv];	
+			

--- a/src/de/darmstadt/tu/crossing/tink/SignatureKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/SignatureKeyTemplates.cryptsl
@@ -1,0 +1,36 @@
+/*
+ * This is a CrySL specification for the Google Tink implementation of 
+ * the class SignatureKeyTemplates. 
+ * 
+ * Note: in this case, we are not specifying the correct usage of the 
+ * API, but actually guaranteeing that the Google Tink API implementation 
+ * actually exposes some key templates as static attributes. This 
+ * information simplifies the specification of other properties for 
+ * correctly using the API. 
+ * 
+ */
+
+SPEC com.google.crypto.tink.signature.SignatureKeyTemplates
+
+OBJECTS
+	com.google.crypto.tink.proto.KeyTemplate ecdsa;
+	
+	com.google.crypto.tink.proto.HashType hashType;
+	com.google.crypto.tink.proto.EllipticCurveType curveType;
+	
+EVENTS
+	ecdsa_evt : ecdsa = createEcdsaKeyTemplate(hashType, curveType, _);
+	
+	CreateKeyTemplates := ecdsa_evt;
+	
+ORDER 
+	(CreateKeyTemplates)
+
+//CONSTRAINTS
+ 	//hashType in {SHA256, SHA52}
+	//curveType in {NIST_P384, NIST_P521, NIST_P256}	
+	//hashType == SHA256 => curveType == P256
+	//hashType == SHA512 => curveType in {NIST_P384, NIST_P521} 
+	 
+ENSURES
+	keyTemplate[ecdsa];

--- a/src/de/darmstadt/tu/crossing/tink/SignatureKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/SignatureKeyTemplates.cryptsl
@@ -21,10 +21,8 @@ OBJECTS
 EVENTS
 	ecdsa_evt : ecdsa = createEcdsaKeyTemplate(hashType, curveType, _);
 	
-	CreateKeyTemplates := ecdsa_evt;
-	
 ORDER 
-	(CreateKeyTemplates)
+	ecdsa_evt
 
 //CONSTRAINTS
  	//hashType in {SHA256, SHA52}

--- a/src/de/darmstadt/tu/crossing/tink/StreamingAead.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/StreamingAead.cryptsl
@@ -1,0 +1,21 @@
+/*
+ * A CrySL specification for using the Streaming AEAD Ciphers (Authenticated 
+ * Encryption with Associated Data) of the Google Tink library, together with a 
+ * ReadableByteChannel. 
+ */
+SPEC com.google.crypto.tink.StreamingAead
+
+OBJECTS 
+	java.nio.channels.WritableByteChannel writer; 
+	java.nio.channels.ReadableByteChannel reader; 
+
+EVENTS
+	create_writable_channel_evt : writer = newEncryptingChannel(_, _);
+	create_readable_channel_evt : reader = newDecryptingChannel(_, _);
+ 
+
+ORDER 
+	(create_writable_channel_evt | create_readable_channel_evt)+
+	
+REQUIRES
+	streamingAeadPrimitive[this];

--- a/src/de/darmstadt/tu/crossing/tink/StreamingAeadFactory.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/StreamingAeadFactory.cryptsl
@@ -1,0 +1,21 @@
+/*
+ * A CrySL specification for using the Deterministic AEAD Factory 
+ * of the Google Google library. 
+ */
+SPEC com.google.crypto.tink.streamingaead.StreamingAeadFactory
+
+OBJECTS
+	com.google.crypto.tink.KeysetHandle ksh;
+	com.google.crypto.tink.StreamingAead saead; 
+
+EVENTS
+	gp : saead = getPrimitive(ksh);
+
+ORDER
+	gp
+
+REQUIRES 
+	generatedKeySet[ksh]; 
+	
+ENSURES
+	streamingAeadPrimitive[saead];

--- a/src/de/darmstadt/tu/crossing/tink/StreamingAeadKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/StreamingAeadKeyTemplates.cryptsl
@@ -1,0 +1,47 @@
+/*
+ * This is a CrySL specification for the Google Tink implementation of 
+ * the class StreamingAeadKeyTemplates. 
+ * 
+ * Note: in this case, we are not specifying the correct usage of the 
+ * API, but actually guaranteeing that the Google Tink API implementation 
+ * actually exposes some key templates as static attributes. This 
+ * information simplifies the specification of other properties for 
+ * correctly using the API. 
+ * 
+ * 
+ * It constraints the use of the API to the following key templates: 
+ * 
+ * - aes_ctr_hmac_sha256_4kb_evt
+ * - aes_gcm_hkdf_4kb_evt
+ */
+
+SPEC com.google.crypto.tink.streamingaead.StreamingAeadKeyTemplates
+
+OBJECTS
+	com.google.crypto.tink.proto.KeyTemplate aes_ctr_hmac_sha256_4kb;
+	com.google.crypto.tink.proto.KeyTemplate aes_gcm_hkdf_4kb; 
+		
+	int key;
+	int tag32;
+	int segmentSize; 
+	
+	
+EVENTS
+   	aes_ctr_hmac_sha256_4kb_evt: aes_ctr_hmac_sha256_4kb = createAesCtrHmacStreamingKeyTemplate(key, _, key, _, tag32, segmentSize);
+	aes_gcm_hkdf_4kb_evt : aes_gcm_hkdf_4kb = createAesGcmHkdfStreamingKeyTemplate(key, _, key, segmentSize);
+	
+	CreateKeyTemplates := aes_ctr_hmac_sha256_4kb_evt | aes_gcm_hkdf_4kb_evt;
+	
+ORDER 
+	(CreateKeyTemplates)*	
+
+CONSTRAINTS
+	key in {16, 32};
+	tag32 == 32; 
+	segmentSize == 4096;
+	
+ENSURES
+	keyTemplate[aes_ctr_hmac_sha256_4kb];
+	keyTemplate[aes_gcm_hkdf_4kb];
+	
+	

--- a/src/de/darmstadt/tu/crossing/tink/StreamingAeadKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/StreamingAeadKeyTemplates.cryptsl
@@ -11,8 +11,8 @@
  * 
  * It constraints the use of the API to the following key templates: 
  * 
- * - aes_ctr_hmac_sha256_4kb_evt
- * - aes_gcm_hkdf_4kb_evt
+ * - aes_ctr_hmac_sha256_4kb
+ * - aes_gcm_hkdf_4kb
  */
 
 SPEC com.google.crypto.tink.streamingaead.StreamingAeadKeyTemplates

--- a/src/de/darmstadt/tu/crossing/tink/StreamingAeadKeyTemplates.cryptsl
+++ b/src/de/darmstadt/tu/crossing/tink/StreamingAeadKeyTemplates.cryptsl
@@ -37,8 +37,8 @@ ORDER
 
 CONSTRAINTS
 	key in {16, 32};
-	tag32 == 32; 
-	segmentSize == 4096;
+	tag32 in {32}; 
+	segmentSize in {4096};
 	
 ENSURES
 	keyTemplate[aes_ctr_hmac_sha256_4kb];


### PR DESCRIPTION
CrySL rules for the following Google Tink primitives:

- AEAD
- Streaming AEAD
- Deterministic AEAD
- MAC
- Digital Signature
- Hybrid Encryption 