### PR TITLE
Parentheses are replaced with square brackets (related to cryptsl issue #13 ).

### DIFF
--- a/JavaCryptographicArchitecture/src/Cipher.cryptsl
+++ b/JavaCryptographicArchitecture/src/Cipher.cryptsl
@@ -82,14 +82,14 @@ CONSTRAINTS
     part(0, "/", transformation) in {"AES"} && part(1, "/", transformation) in {"CBC", "PCBC"} => part(2, "/", transformation) in {"PKCS7Padding", "PKCS5Padding", "ISO10126Padding"};
     part(0, "/", transformation) in {"AES"} && part(1, "/", transformation) in {"GCM", "CTR", "CFB", "OFB"} => part(2, "/", transformation) in {"NoPadding"};
 	
-	part(1, "/", transformation) in {"CBC", "PCBC", "CTR", "CTS", "CFB", "OFB"} && encmode != 1 => noCallTo(IWOIV) ;
-    part(1, "/", transformation) in {"CBC", "PCBC", "CTR", "CTS", "CFB", "OFB"} && encmode == 1 => callTo(iv) ;     
+	part(1, "/", transformation) in {"CBC", "PCBC", "CTR", "CTS", "CFB", "OFB"} && encmode != 1 => noCallTo[IWOIV];
+    part(1, "/", transformation) in {"CBC", "PCBC", "CTR", "CTS", "CFB", "OFB"} && encmode == 1 => callTo[iv];     
     
     encmode in {1,2,3,4};
-    length(pre_plaintext) >= pre_plain_off + len;
-    length(pre_ciphertext) <= pre_ciphertext_off;
-    length(plainText) <= plain_off + len;
-    length(cipherText) <= ciphertext_off;
+    length[pre_plaintext] >= pre_plain_off + len;
+    length[pre_ciphertext] <= pre_ciphertext_off;
+    length[plainText] <= plain_off + len;
+    length[cipherText] <= ciphertext_off;
 
 REQUIRES
 	generatedKey[key, part(0, "/", transformation)];

--- a/JavaCryptographicArchitecture/src/KeyManagerFactory.cryptsl
+++ b/JavaCryptographicArchitecture/src/KeyManagerFactory.cryptsl
@@ -22,7 +22,7 @@ ORDER
 	Gets, Init, gkm?
 
 CONSTRAINTS
-    neverTypeOf(password, java.lang.String) ;
+    neverTypeOf[password, java.lang.String];
     algo in {"PKIX", "SunX509"};
 
 REQUIRES

--- a/JavaCryptographicArchitecture/src/KeyStore.cryptsl
+++ b/JavaCryptographicArchitecture/src/KeyStore.cryptsl
@@ -50,9 +50,9 @@ ORDER
     Gets, Loads, ((gE?, gk) | (sE, Stores))*
 
 CONSTRAINTS
-    neverTypeOf(passwordIn, java.lang.String) ;
-    neverTypeOf(passwordOut, java.lang.String) ;
-    neverTypeOf(passwordKey, java.lang.String) ;
+    neverTypeOf[passwordIn, java.lang.String];
+    neverTypeOf[passwordOut, java.lang.String];
+    neverTypeOf[passwordKey, java.lang.String];
 
 ENSURES
 	generatedKeyStore[this] after Loads;

--- a/JavaCryptographicArchitecture/src/Mac.cryptsl
+++ b/JavaCryptographicArchitecture/src/Mac.cryptsl
@@ -40,7 +40,7 @@ ORDER
 CONSTRAINTS
     macAlg in {"HmacMD5", "HmacSHA1", "HmacSHA224", "HmacSHA256", "HmacSHA384", "HmacSHA512", "HmacPBESHA1", "PBEWithHmacSHA1", "PBEWithHmacSHA224", "PBEWithHmacSHA256", "PBEWithHmacSHA384", "PBEWithHmacSHA512"};
     offset < len;
-    length(output1) > outOffset;
+    length[output1] > outOffset;
     
 REQUIRES
     !encrypted[output1, _];

--- a/JavaCryptographicArchitecture/src/PBEKeySpec.cryptsl
+++ b/JavaCryptographicArchitecture/src/PBEKeySpec.cryptsl
@@ -17,7 +17,7 @@ ORDER
  	c1,  cP
 CONSTRAINTS
 	iterationCount >= 10000;
-	neverTypeOf(password, java.lang.String) ;
+	neverTypeOf[password, java.lang.String];
 
 REQUIRES
 	randomized[salt];	

--- a/JavaCryptographicArchitecture/src/SecretKeySpec.cryptsl
+++ b/JavaCryptographicArchitecture/src/SecretKeySpec.cryptsl
@@ -13,7 +13,7 @@ EVENTS
 ORDER
  	Cons
 CONSTRAINTS
-	length(keyMaterial) >= off + len;
+	length[keyMaterial] >= off + len;
 	
 REQUIRES
 	preparedKeyMaterial[keyMaterial];	


### PR DESCRIPTION
Parentheses in predefinedpredicates' rules  are replaced with square brackets.