### PR TITLE
Deprecated support for TLSv1.1 in SSLContext JCA default rule

### DIFF
--- a/JavaCryptographicArchitecture/src/SSLContext.cryptsl
+++ b/JavaCryptographicArchitecture/src/SSLContext.cryptsl
@@ -25,7 +25,7 @@ ORDER
 	Gets, Init, Engine? 
 
 CONSTRAINTS
-	protocol in {"TLSv1.1", "TLSv1.2"};
+	protocol in {"TLSv1.2"};
 
 REQUIRES
 	generatedKeyManager[kms];


### PR DESCRIPTION
Closed #51 