### PR TITLE
Update KeyAgreement.cryptsl

### DIFF
--- a/BouncyCastle-JCA/src/KeyAgreement.cryptsl
+++ b/BouncyCastle-JCA/src/KeyAgreement.cryptsl
@@ -30,7 +30,7 @@ ORDER
 	Gets, Inits, dp, GenSecret
 	
 CONSTRAINTS
-	algorithm in {"DH", "DiffieHellman", "ECDH", "NH"};
+	algorithm in {"DH", "DiffieHellman", "NH"};
 	
 REQUIRES
     randomized[random];


### PR DESCRIPTION
The ECDH algorithm needs to be deprecated as discussed in the meeting today.