### PR TITLE
Missing padding mode in Cipher rule

### DIFF
--- a/JavaCryptographicArchitecture/src/Cipher.crysl
+++ b/JavaCryptographicArchitecture/src/Cipher.crysl
@@ -81,7 +81,7 @@ CONSTRAINTS
 
     alg(transformation) in {"PBEWithHmacSHA224AndAES_128", "PBEWithHmacSHA256AndAES_128", "PBEWithHmacSHA384AndAES_128", "PBEWithHmacSHA512AndAES_128", "PBEWithHmacSHA224AndAES_256", "PBEWithHmacSHA256AndAES_256", "PBEWithHmacSHA384AndAES_256", "PBEWithHmacSHA512AndAES_256"} => pad(transformation) in {"PKCS5Padding"};
     alg(transformation) in {"RSA"} && mode(transformation) in {""} => pad(transformation) in {""};
-	alg(transformation) in {"RSA"} && mode(transformation) in {"ECB"} => pad(transformation) in {"PKCS1Padding","OAEPWithMD5AndMGF1Padding", "OAEPWithSHA-224AndMGF1Padding", "OAEPWithSHA-256AndMGF1Padding", "OAEPWithSHA-384AndMGF1Padding", "OAEPWithSHA-512AndMGF1Padding"};
+	alg(transformation) in {"RSA"} && mode(transformation) in {"ECB"} => pad(transformation) in {"NoPadding", "PKCS1Padding","OAEPWithMD5AndMGF1Padding", "OAEPWithSHA-224AndMGF1Padding", "OAEPWithSHA-256AndMGF1Padding", "OAEPWithSHA-384AndMGF1Padding", "OAEPWithSHA-512AndMGF1Padding"};
 	
    	alg(transformation) in {"AES"} && mode(transformation) in {"CBC", "PCBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
     alg(transformation) in {"AES"} && mode(transformation) in {"GCM", "CTR", "CTS", "CFB", "OFB"} => pad(transformation) in {"NoPadding"};


### PR DESCRIPTION
When an algorithm is of type RSA and block mode ECB, the NOPADDING padding mode is missing. This is a secure one, as stated in this Java [documentation](https://docs.oracle.com/javase/6/docs/technotes/guides/security/SunProviders.html#SunJCEProvider).