### PR TITLE
Removed TLS 1.1 from the rules

### DIFF
--- a/JavaCryptographicArchitecture/src/SSLEngine.crysl
+++ b/JavaCryptographicArchitecture/src/SSLEngine.crysl
@@ -13,7 +13,7 @@ ORDER
 	(ec,ep) | (ep,ec) 
 
 CONSTRAINTS
-	elements(protocols) in {"TLSv1.2","TLSv1.1"};
+	elements(protocols) in {"TLSv1.2"};
 	elements(ciphersuites) in {"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
 							"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 							"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",

--- a/JavaCryptographicArchitecture/src/SSLParameters.crysl
+++ b/JavaCryptographicArchitecture/src/SSLParameters.crysl
@@ -17,7 +17,7 @@ ORDER
 	(C1, ((CS , PR) | (PR , CS))) | (C2, PR) | C3
 		
 CONSTRAINTS
-	elements(protocols) in {"TLSv1.2","TLSv1.1"};
+	elements(protocols) in {"TLSv1.2"};
 	elements(ciphersuites) in {"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
 							"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 							"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",


### PR DESCRIPTION
The TLS 1.1 is not deemed secure anymore and thus is removed from the rules.
Sources:
https://www.bleepingcomputer.com/news/security/tls-10-and-tls-11-being-retired-in-2020-by-all-major-browsers/
https://blogs.windows.com/msedgedev/2020/03/31/tls-1-0-tls-1-1-schedule-update-edge-ie11/