### PR TITLE
Update BouncyCastle-JCA ruleset

### DIFF
--- a/BouncyCastle-JCA/pom.xml
+++ b/BouncyCastle-JCA/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.paderborn.uni</groupId>
 	<artifactId>BouncyCastle-JCA</artifactId>
-	<version>0.3</version>
+	<version>0.4</version>
 	<name>CrySL Rules Bundle</name>
 	<dependencies>
 		<!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on -->

--- a/BouncyCastle-JCA/src/AlgorithmParameterGenerator.crysl
+++ b/BouncyCastle-JCA/src/AlgorithmParameterGenerator.crysl
@@ -1,4 +1,5 @@
 SPEC java.security.AlgorithmParameterGenerator
+
 OBJECTS
 	java.lang.String algorithm;
     java.security.spec.AlgorithmParameterSpec genParamSpec; 

--- a/BouncyCastle-JCA/src/AlgorithmParameterGenerator.crysl
+++ b/BouncyCastle-JCA/src/AlgorithmParameterGenerator.crysl
@@ -2,22 +2,22 @@ SPEC java.security.AlgorithmParameterGenerator
 
 OBJECTS
 	java.lang.String algorithm;
-    java.security.spec.AlgorithmParameterSpec genParamSpec; 
+	java.security.spec.AlgorithmParameterSpec genParamSpec; 
 	java.security.SecureRandom random;
 	int size;
 
 EVENTS
 	g1: getInstance(algorithm);
-    g2: getInstance(algorithm, _);
-    Gets := g1 | g2;
+	g2: getInstance(algorithm, _);
+	Gets := g1 | g2;
 
-    i1: init(size);
-    i2: init(size, random);
-    i3: init(genParamSpec);
-    i4: init(genParamSpec, random);
-    Inits := i1 | i2 | i3 | i4;
+	i1: init(size);
+	i2: init(size, random);
+	i3: init(genParamSpec);
+	i4: init(genParamSpec, random);
+	Inits := i1 | i2 | i3 | i4;
     
-    GenParam: generateParameters();
+	GenParam: generateParameters();
     
 ORDER
 	Gets, Inits, GenParam

--- a/BouncyCastle-JCA/src/AlgorithmParameterGenerator.crysl
+++ b/BouncyCastle-JCA/src/AlgorithmParameterGenerator.crysl
@@ -17,14 +17,14 @@ EVENTS
     i4: init(genParamSpec, random);
     Inits := i1 | i2 | i3 | i4;
     
-    Gen: generateParameters();
+    GenParam: generateParameters();
     
 ORDER
-	Gets, Inits, Gen
+	Gets, Inits, GenParam
 	
 CONSTRAINTS
 	algorithm in {"AES", "Camellia", "Shacal2", "Shacal-2", "DH", "DiffieHellman", "DSA", "ElGamal"};
 	
 ENSURES
-	genAlgParam[this, algorithm] after Gen;
+	genAlgParam[this, algorithm] after GenParam;
 	

--- a/BouncyCastle-JCA/src/AlgorithmParameterGenerator.crysl
+++ b/BouncyCastle-JCA/src/AlgorithmParameterGenerator.crysl
@@ -26,5 +26,5 @@ CONSTRAINTS
 	algorithm in {"AES", "Camellia", "Shacal2", "Shacal-2", "DH", "DiffieHellman", "DSA", "ElGamal"};
 	
 ENSURES
-	genAlgParam[this, algorithm] after GenParam;
+	genAlgParam[algorithm];
 	

--- a/BouncyCastle-JCA/src/AlgorithmParameters.crysl
+++ b/BouncyCastle-JCA/src/AlgorithmParameters.crysl
@@ -1,4 +1,5 @@
 SPEC java.security.AlgorithmParameters
+
 OBJECTS
     java.lang.String alg;
     java.security.spec.AlgorithmParameterSpec params;
@@ -31,7 +32,7 @@ CONSTRAINTS
 			"SHA3-256WITHRSAANDMGF1", "SHA3-386WITHRSAANDMGF1", "SHA3-512WITHRSAANDMGF1"};
 
 REQUIRES    
-    preparedAlg[parAr];
+    preparedAlg[parAr, alg];
     alg in {"AES", "Camellia", "ChaCha7539", "ElGamal", "PBKDF2", "Rijndael", "Salsa20", "Tnepres", "Serpent", "SHACAL-2", 
     		"Shacal2", "Twofish", "XSalsa20", "OAEP", "PSS", "RSAPSS", "SHA256withRSA/PSS", "SHA384withRSA/PSS", "SHA512withRSA/PSS",
     		"SHA256WITHRSAANDMGF1", "SHA386WITHRSAANDMGF1", "SHA512WITHRSAANDMGF1", "SHA3-256WITHRSAANDMGF1", "SHA3-386WITHRSAANDMGF1", 

--- a/BouncyCastle-JCA/src/AlgorithmParameters.crysl
+++ b/BouncyCastle-JCA/src/AlgorithmParameters.crysl
@@ -19,10 +19,10 @@ EVENTS
     
     e1: parsRes = getEncoded();
     e2: parsRes = getEncoded(format);
-    Encoded := e1 | e2;
+    GetEncs := e1 | e2;
 
 ORDER
-    Gets, Inits, Encoded?
+    Gets, Inits, GetEncs?
 
 CONSTRAINTS
 	alg in {"AES", "Camellia", "ChaCha7539", "DSA", "DiffieHellman", "DH", "EC", "ElGamal", "PBKDF2", 
@@ -43,4 +43,5 @@ REQUIRES
     
 ENSURES 
     preparedAlg[this, alg] after Inits;
-    preparedAlg[parsRes, alg] after Encoded;
+    preparedAlg[parsRes, alg] after GetEncs;
+    

--- a/BouncyCastle-JCA/src/AlgorithmParameters.crysl
+++ b/BouncyCastle-JCA/src/AlgorithmParameters.crysl
@@ -1,28 +1,28 @@
 SPEC java.security.AlgorithmParameters
 
 OBJECTS
-    java.lang.String alg;
-    java.security.spec.AlgorithmParameterSpec params;
+	java.lang.String alg;
+	java.security.spec.AlgorithmParameterSpec params;
 	byte[] parAr; 
 	java.lang.String format;
 	byte[] parsRes;
 
 EVENTS
-    g1: getInstance(alg);
-    g2: getInstance(alg, _);
-    Gets := g1 | g2;
+	g1: getInstance(alg);
+	g2: getInstance(alg, _);
+	Gets := g1 | g2;
 
-    i1: init(params);
-    i2: init(parAr);
-    i3: init(parAr, _);
-    Inits := i1 | i2 | i3;
+	i1: init(params);
+	i2: init(parAr);
+	i3: init(parAr, _);
+	Inits := i1 | i2 | i3;
     
-    e1: parsRes = getEncoded();
-    e2: parsRes = getEncoded(format);
-    GetEncs := e1 | e2;
+	e1: parsRes = getEncoded();
+	e2: parsRes = getEncoded(format);
+	GetEncs := e1 | e2;
 
 ORDER
-    Gets, Inits, GetEncs?
+	Gets, Inits, GetEncs?
 
 CONSTRAINTS
 	alg in {"AES", "Camellia", "ChaCha7539", "DSA", "DiffieHellman", "DH", "EC", "ElGamal", "PBKDF2", 
@@ -32,16 +32,16 @@ CONSTRAINTS
 			"SHA3-256WITHRSAANDMGF1", "SHA3-386WITHRSAANDMGF1", "SHA3-512WITHRSAANDMGF1"};
 
 REQUIRES    
-    preparedAlg[parAr, alg];
-    alg in {"AES", "Camellia", "ChaCha7539", "ElGamal", "PBKDF2", "Rijndael", "Salsa20", "Tnepres", "Serpent", "SHACAL-2", 
+	preparedAlg[parAr, alg];
+	alg in {"AES", "Camellia", "ChaCha7539", "ElGamal", "PBKDF2", "Rijndael", "Salsa20", "Tnepres", "Serpent", "SHACAL-2", 
     		"Shacal2", "Twofish", "XSalsa20", "OAEP", "PSS", "RSAPSS", "SHA256withRSA/PSS", "SHA384withRSA/PSS", "SHA512withRSA/PSS",
     		"SHA256WITHRSAANDMGF1", "SHA386WITHRSAANDMGF1", "SHA512WITHRSAANDMGF1", "SHA3-256WITHRSAANDMGF1", "SHA3-386WITHRSAANDMGF1", 
     		"SHA3-512WITHRSAANDMGF1"} => preparedIV[params];
-    alg in {"DiffieHellman", "DH"} => preparedDH[params];
-    alg in {"DSA"} => preparedDSA[params];
-    alg in {"EC"} => preparedEC[params];
+	alg in {"DiffieHellman", "DH"} => preparedDH[params];
+	alg in {"DSA"} => preparedDSA[params];
+	alg in {"EC"} => preparedEC[params];
     
 ENSURES 
-    preparedAlg[this, alg] after Inits;
-    preparedAlg[parsRes, alg] after GetEncs;
+	preparedAlg[this, alg] after Inits;
+	preparedAlg[parsRes, alg] after GetEncs;
     

--- a/BouncyCastle-JCA/src/CertPathTrustManagerParameters.crysl
+++ b/BouncyCastle-JCA/src/CertPathTrustManagerParameters.crysl
@@ -4,13 +4,14 @@ OBJECTS
 	java.security.cert.CertPathParameters params;
 
 EVENTS
-	c: CertPathTrustManagerParameters(params);	
+	Con: CertPathTrustManagerParameters(params);	
 	
 ORDER
-	c
+	Con
 
 REQUIRES
 	generatedCertPathParameters[params];
 	
 ENSURES
 	generatedManagerFactoryParameters[this];
+	

--- a/BouncyCastle-JCA/src/CertPathTrustManagerParameters.crysl
+++ b/BouncyCastle-JCA/src/CertPathTrustManagerParameters.crysl
@@ -4,10 +4,10 @@ OBJECTS
 	java.security.cert.CertPathParameters params;
 
 EVENTS
-	C: CertPathTrustManagerParameters(params);	
+	c: CertPathTrustManagerParameters(params);	
 	
 ORDER
-	C
+	c
 
 REQUIRES
 	generatedCertPathParameters[params];

--- a/BouncyCastle-JCA/src/CertificateFactory.crysl
+++ b/BouncyCastle-JCA/src/CertificateFactory.crysl
@@ -26,4 +26,4 @@ CONSTRAINTS
 	encoding in {"PKCS7", "PkiPath"};
 	
 ENSURES
-	genCert[alg];
+	generatedCert[alg];

--- a/BouncyCastle-JCA/src/CertificateFactory.crysl
+++ b/BouncyCastle-JCA/src/CertificateFactory.crysl
@@ -14,12 +14,12 @@ EVENTS
 	
 	gen1: generateCertPath(inStream);
 	gen2: generateCertPath(inStream, encoding);
-	GenCertPath := gen1 | gen2;
+	GenCertPaths := gen1 | gen2;
 	
 	GenCRL: generateCRL(inStream);
 	
 ORDER
-	Gets, (GenCert | GenCertPath | GenCRL)+
+	Gets, (GenCert | GenCertPaths | GenCRL)+
 	
 CONSTRAINTS
 	alg in {"X509", "X.509"};

--- a/BouncyCastle-JCA/src/Cipher.crysl
+++ b/BouncyCastle-JCA/src/Cipher.crysl
@@ -1,29 +1,29 @@
 SPEC javax.crypto.Cipher
 
 OBJECTS
-    java.lang.String transformation;
-    int encmode;
-    java.security.Key key;
-    java.security.cert.Certificate cert;
-    java.security.spec.AlgorithmParameterSpec params;
-    java.security.AlgorithmParameters param;
+	java.lang.String transformation;
+	int encmode;
+	java.security.Key key;
+	java.security.cert.Certificate cert;
+	java.security.spec.AlgorithmParameterSpec params;
+	java.security.AlgorithmParameters param;
     
-    int pre_plain_off;
-    int pre_ciphertext_off;
-    int plain_off;
-    int ciphertext_off;
+	int pre_plain_off;
+	int pre_ciphertext_off;
+	int plain_off;
+	int ciphertext_off;
     
-    int pre_len;
-    int len;
+	int pre_len;
+	int len;
     
-    byte[] pre_plaintext;
-    byte[] pre_ciphertext;
-    java.nio.ByteBuffer pre_plainBuffer;
+	byte[] pre_plaintext;
+	byte[] pre_ciphertext;
+	java.nio.ByteBuffer pre_plainBuffer;
 	java.nio.ByteBuffer pre_cipherBuffer;
     
-    byte[] plainText;
-    byte[] cipherText;
-    byte[] wrappedKeyBytes;
+	byte[] plainText;
+	byte[] cipherText;
+	byte[] wrappedKeyBytes;
 	java.nio.ByteBuffer plainBuffer;
 	java.nio.ByteBuffer cipherBuffer;
 	
@@ -32,45 +32,45 @@ OBJECTS
 	java.security.Key wrappedKey;
 
 EVENTS
-    g1: getInstance(transformation);
-    g2: getInstance(transformation, _);
-    Gets := g1 | g2;
+	g1: getInstance(transformation);
+	g2: getInstance(transformation, _);
+	Gets := g1 | g2;
 
-    i1: init(encmode, cert);
-    i2: init(encmode, cert, ranGen);
-    i3: init(encmode, key);
-    i4: init(encmode, key, params);
-    i5: init(encmode, key, param);
-    i6: init(encmode, key, params, ranGen);
-    i7: init(encmode, key, param, ranGen);
-    i8: init(encmode, key, ranGen);
-    IWOIV := i1 | i2 | i3 | i8;
-    IWIV :=  i4 | i5 | i6 | i7;
-    Inits := IWOIV | IWIV;
+	i1: init(encmode, cert);
+	i2: init(encmode, cert, ranGen);
+	i3: init(encmode, key);
+	i4: init(encmode, key, params);
+	i5: init(encmode, key, param);
+	i6: init(encmode, key, params, ranGen);
+	i7: init(encmode, key, param, ranGen);
+	i8: init(encmode, key, ranGen);
+	IWOIV := i1 | i2 | i3 | i8;
+	IWIV :=  i4 | i5 | i6 | i7;
+	Inits := IWOIV | IWIV;
 
-    u1: pre_ciphertext = update(pre_plaintext);
-    u2: pre_ciphertext = update(pre_plaintext, pre_plain_off, _);
-    u3: update(pre_plaintext, pre_plain_off, pre_len, pre_ciphertext);
-    u4: update(pre_plaintext, pre_plain_off, pre_len, pre_ciphertext, pre_ciphertext_off);
-    u5: update(pre_plainBuffer, pre_cipherBuffer);
-    Updates := u1 | u2 | u3 | u4 | u5;
+	u1: pre_ciphertext = update(pre_plaintext);
+	u2: pre_ciphertext = update(pre_plaintext, pre_plain_off, _);
+	u3: update(pre_plaintext, pre_plain_off, pre_len, pre_ciphertext);
+	u4: update(pre_plaintext, pre_plain_off, pre_len, pre_ciphertext, pre_ciphertext_off);
+	u5: update(pre_plainBuffer, pre_cipherBuffer);
+	Updates := u1 | u2 | u3 | u4 | u5;
 
-    f1: cipherText = doFinal();
-    f2: cipherText =  doFinal(plainText);
-    f3: doFinal(cipherText, ciphertext_off);
-    f4: cipherText = doFinal(plainText, plain_off, len);
-    f5: doFinal(plainText, plain_off, len, cipherText);
-    f6: doFinal(plainText, plain_off, len, cipherText, ciphertext_off);
-    f7: doFinal(plainBuffer, cipherBuffer);
-    FINWOU := f2 | f4 | f5 | f6 | f7;
-    DOFINALS := FINWOU | f1 | f3;
+	f1: cipherText = doFinal();
+	f2: cipherText =  doFinal(plainText);
+	f3: doFinal(cipherText, ciphertext_off);
+	f4: cipherText = doFinal(plainText, plain_off, len);
+	f5: doFinal(plainText, plain_off, len, cipherText);
+	f6: doFinal(plainText, plain_off, len, cipherText, ciphertext_off);
+	f7: doFinal(plainBuffer, cipherBuffer);
+	FINWOU := f2 | f4 | f5 | f6 | f7;
+	DOFINALS := FINWOU | f1 | f3;
     
-    WKB: wrappedKeyBytes = wrap(wrappedKey);
+	WKB: wrappedKeyBytes = wrap(wrappedKey);
     
-    IV: getIV();
+	IV: getIV();
     
 ORDER
-    Gets, Inits+, WKB+ | (FINWOU | (Updates+, DOFINALS))+
+	Gets, Inits+, WKB+ | (FINWOU | (Updates+, DOFINALS))+
 
 CONSTRAINTS
 	instanceOf[key, java.security.PublicKey] || instanceOf[key, java.security.PrivateKey] || encmode in {3, 4} => alg(transformation) in {"RSA"};
@@ -79,46 +79,46 @@ CONSTRAINTS
 	noCallTo[Inits] => alg(transformation) in {"AES", "RSA", "RIJNDAEL", "ElGamal", "ECIESwithAES-CBC", "DHIESwithAES-CBC", "Twofish", "Camellia", "Serpent", "Tnepres", 
 																		"Shacal2", "Shacal-2", "McEliece", "McEliecePointcheval", "McElieceKobaraImai", "McElieceFujisaki"};
 																		
-    alg(transformation) in {"AES"} => mode(transformation) in {"CBC", "GCM", "CTR", "CTS", "CFB", "OFB", "CCM"};
-    alg(transformation) in {"RIJNDAEL"} => mode(transformation) in {"CBC", "GCM", "CTR", "CTS", "CFB", "OFB", "CCM"};
-    alg(transformation) in {"ElGamal"} => mode(transformation) in {"ECB"};
-    alg(transformation) in {"Twofish"} => mode(transformation) in {"CBC"};
-    alg(transformation) in {"Camellia"} => mode(transformation) in {"CBC"};
-    alg(transformation) in {"Serpent"} => mode(transformation) in {"CBC", "CFB", "OFB"};
-    alg(transformation) in {"Tnepres"} => mode(transformation) in {"CBC", "CFB", "OFB"};
-    alg(transformation) in {"Shacal2"} => mode(transformation) in {"CBC"};
-    alg(transformation) in {"Shacal-2"} => mode(transformation) in {"CBC"};
+	alg(transformation) in {"AES"} => mode(transformation) in {"CBC", "GCM", "CTR", "CTS", "CFB", "OFB", "CCM"};
+	alg(transformation) in {"RIJNDAEL"} => mode(transformation) in {"CBC", "GCM", "CTR", "CTS", "CFB", "OFB", "CCM"};
+	alg(transformation) in {"ElGamal"} => mode(transformation) in {"ECB"};
+	alg(transformation) in {"Twofish"} => mode(transformation) in {"CBC"};
+	alg(transformation) in {"Camellia"} => mode(transformation) in {"CBC"};
+	alg(transformation) in {"Serpent"} => mode(transformation) in {"CBC", "CFB", "OFB"};
+	alg(transformation) in {"Tnepres"} => mode(transformation) in {"CBC", "CFB", "OFB"};
+	alg(transformation) in {"Shacal2"} => mode(transformation) in {"CBC"};
+	alg(transformation) in {"Shacal-2"} => mode(transformation) in {"CBC"};
     
-    alg(transformation) in {"ElGamal"} && mode(transformation) in {"ECB"} => pad(transformation) in {"PKCS1Padding"};
-    alg(transformation) in {"RSA"} && mode(transformation) in {""} => pad(transformation) in {""};
+	alg(transformation) in {"ElGamal"} && mode(transformation) in {"ECB"} => pad(transformation) in {"PKCS1Padding"};
+	alg(transformation) in {"RSA"} && mode(transformation) in {""} => pad(transformation) in {""};
 	alg(transformation) in {"RSA"} && mode(transformation) in {"ECB"} => pad(transformation) in {"PKCS1Padding","OAEPWithMD5AndMGF1Padding", "OAEPWithSHA-224AndMGF1Padding", "OAEPWithSHA-256AndMGF1Padding", "OAEPWithSHA-384AndMGF1Padding", "OAEPWithSHA-512AndMGF1Padding"};
-   	alg(transformation) in {"AES"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
-    alg(transformation) in {"AES"} && mode(transformation) in {"GCM", "CTR", "CTS", "CFB", "OFB", "CCM"} => pad(transformation) in {"NoPadding"};
-    alg(transformation) in {"RIJNDAEL"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
-    alg(transformation) in {"RIJNDAEL"} && mode(transformation) in {"GCM", "CTR", "CTS", "CFB", "OFB", "CCM"} => pad(transformation) in {"NoPadding"};
-    alg(transformation) in {"Serpent"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
-    alg(transformation) in {"Serpent"} && mode(transformation) in {"CFB", "OFB"} => pad(transformation) in {"NoPadding"};
-    alg(transformation) in {"Tnepres"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
-    alg(transformation) in {"Tnepres"} && mode(transformation) in {"CFB", "OFB"} => pad(transformation) in {"NoPadding"};
-    alg(transformation) in {"Twofish"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
-    alg(transformation) in {"Camellia"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
-    alg(transformation) in {"Shacal2"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
-    alg(transformation) in {"Shacal-2"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
+	alg(transformation) in {"AES"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
+	alg(transformation) in {"AES"} && mode(transformation) in {"GCM", "CTR", "CTS", "CFB", "OFB", "CCM"} => pad(transformation) in {"NoPadding"};
+	alg(transformation) in {"RIJNDAEL"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
+	alg(transformation) in {"RIJNDAEL"} && mode(transformation) in {"GCM", "CTR", "CTS", "CFB", "OFB", "CCM"} => pad(transformation) in {"NoPadding"};
+	alg(transformation) in {"Serpent"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
+	alg(transformation) in {"Serpent"} && mode(transformation) in {"CFB", "OFB"} => pad(transformation) in {"NoPadding"};
+	alg(transformation) in {"Tnepres"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
+	alg(transformation) in {"Tnepres"} && mode(transformation) in {"CFB", "OFB"} => pad(transformation) in {"NoPadding"};
+	alg(transformation) in {"Twofish"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
+	alg(transformation) in {"Camellia"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
+	alg(transformation) in {"Shacal2"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
+	alg(transformation) in {"Shacal-2"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
     
 	mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB", "CCM"} && encmode != 1 => noCallTo[IWOIV];
-    mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB", "CCM"} && encmode == 1 => callTo[IV];
-       
-    encmode in {1,2,3,4};
-    length[pre_plaintext] >= pre_plain_off + len;
-    length[pre_ciphertext] <= pre_ciphertext_off;
-    length[plainText] <= plain_off + len;
-    length[cipherText] <= ciphertext_off;
+	mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB", "CCM"} && encmode == 1 => callTo[IV];
+       	
+	encmode in {1,2,3,4};
+	length[pre_plaintext] >= pre_plain_off + len;
+	length[pre_ciphertext] <= pre_ciphertext_off;
+	length[plainText] <= plain_off + len;
+	length[cipherText] <= ciphertext_off;
 
 REQUIRES
 	generatedKey[key, alg(transformation)];
-    randomized[ranGen];
-    preparedAlg[param, alg(transformation)];
-    !macced[_, plainText];
+	randomized[ranGen];
+	preparedAlg[param, alg(transformation)];
+	!macced[_, plainText];
 	mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB"} && encmode == 1 => preparedIV[params];
 	mode(transformation) in {"GCM"} => preparedGCM[params];
 	mode(transformation) in {"OAEPWithMD5AndMGF1Padding", "OAEPWithSHA-224AndMGF1Padding", "OAEPWithSHA-256AndMGF1Padding", "OAEPWithSHA-384AndMGF1Padding", "OAEPWithSHA-512AndMGF1Padding"} => preparedOAEP[params];

--- a/BouncyCastle-JCA/src/Cipher.crysl
+++ b/BouncyCastle-JCA/src/Cipher.crysl
@@ -65,12 +65,12 @@ EVENTS
     FINWOU := f2 | f4 | f5 | f6 | f7;
     DOFINALS := FINWOU | f1 | f3;
     
-    w: wrappedKeyBytes = wrap(wrappedKey);
+    WKB: wrappedKeyBytes = wrap(wrappedKey);
     
-    iv: getIV();
+    IV: getIV();
     
 ORDER
-    Gets, Inits+, w+ | (FINWOU | (Updates+, DOFINALS))+
+    Gets, Inits+, WKB+ | (FINWOU | (Updates+, DOFINALS))+
 
 CONSTRAINTS
 	instanceOf[key, java.security.PublicKey] || instanceOf[key, java.security.PrivateKey] || encmode in {3, 4} => alg(transformation) in {"RSA"};
@@ -106,8 +106,8 @@ CONSTRAINTS
     alg(transformation) in {"Shacal-2"} && mode(transformation) in {"CBC"} => pad(transformation) in {"PKCS5Padding", "ISO10126Padding"};
     
 	mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB", "CCM"} && encmode != 1 => noCallTo[IWOIV];
-    mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB", "CCM"} && encmode == 1 => callTo[iv];     
-    
+    mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB", "CCM"} && encmode == 1 => callTo[IV];
+       
     encmode in {1,2,3,4};
     length[pre_plaintext] >= pre_plain_off + len;
     length[pre_ciphertext] <= pre_ciphertext_off;
@@ -121,6 +121,7 @@ REQUIRES
     !macced[_, plainText];
 	mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB"} && encmode == 1 => preparedIV[params];
 	mode(transformation) in {"GCM"} => preparedGCM[params];
+	mode(transformation) in {"OAEPWithMD5AndMGF1Padding", "OAEPWithSHA-224AndMGF1Padding", "OAEPWithSHA-256AndMGF1Padding", "OAEPWithSHA-384AndMGF1Padding", "OAEPWithSHA-512AndMGF1Padding"} => preparedOAEP[params];
 	
 ENSURES
 	generatedCipher[this] after Inits;
@@ -128,3 +129,4 @@ ENSURES
 	encrypted[cipherText, plainText];
 	encrypted[cipherBuffer, plainBuffer];
 	wrappedKey[wrappedKeyBytes, wrappedKey];
+	

--- a/BouncyCastle-JCA/src/Cipher.crysl
+++ b/BouncyCastle-JCA/src/Cipher.crysl
@@ -1,4 +1,5 @@
 SPEC javax.crypto.Cipher
+
 OBJECTS
     java.lang.String transformation;
     int encmode;

--- a/BouncyCastle-JCA/src/Cipher.crysl
+++ b/BouncyCastle-JCA/src/Cipher.crysl
@@ -33,7 +33,7 @@ OBJECTS
 
 EVENTS
     g1: getInstance(transformation);
-    g2:getInstance(transformation, _);
+    g2: getInstance(transformation, _);
     Gets := g1 | g2;
 
     i1: init(encmode, cert);
@@ -53,7 +53,7 @@ EVENTS
     u3: update(pre_plaintext, pre_plain_off, pre_len, pre_ciphertext);
     u4: update(pre_plaintext, pre_plain_off, pre_len, pre_ciphertext, pre_ciphertext_off);
     u5: update(pre_plainBuffer, pre_cipherBuffer);
-    updates := u1 | u2 | u3 | u4 | u5;
+    Updates := u1 | u2 | u3 | u4 | u5;
 
     f1: cipherText = doFinal();
     f2: cipherText =  doFinal(plainText);
@@ -70,11 +70,13 @@ EVENTS
     iv: getIV();
     
 ORDER
-    Gets, Inits+, w+ | (FINWOU | (updates+, DOFINALS))+
+    Gets, Inits+, w+ | (FINWOU | (Updates+, DOFINALS))+
 
 CONSTRAINTS
 	instanceOf[key, java.security.PublicKey] || instanceOf[key, java.security.PrivateKey] || encmode in {3, 4} => alg(transformation) in {"RSA"};
 	instanceOf[key, javax.crypto.SecretKey] => alg(transformation) in {"AES", "RIJNDAEL", "ElGamal", "ECIESwithAES-CBC", "DHIESwithAES-CBC", "Twofish", "Camellia", "Serpent", "Tnepres", 
+																		"Shacal2", "Shacal-2", "McEliece", "McEliecePointcheval", "McElieceKobaraImai", "McElieceFujisaki"};
+	noCallTo[Inits] => alg(transformation) in {"AES", "RSA", "RIJNDAEL", "ElGamal", "ECIESwithAES-CBC", "DHIESwithAES-CBC", "Twofish", "Camellia", "Serpent", "Tnepres", 
 																		"Shacal2", "Shacal-2", "McEliece", "McEliecePointcheval", "McElieceKobaraImai", "McElieceFujisaki"};
 																		
     alg(transformation) in {"AES"} => mode(transformation) in {"CBC", "GCM", "CTR", "CTS", "CFB", "OFB", "CCM"};
@@ -121,7 +123,8 @@ REQUIRES
 	mode(transformation) in {"GCM"} => preparedGCM[params];
 	
 ENSURES
-	encrypted[pre_ciphertext, pre_plaintext] after updates; 
+	generatedCipher[this] after Inits;
+	encrypted[pre_ciphertext, pre_plaintext] after Updates; 
 	encrypted[cipherText, plainText];
 	encrypted[cipherBuffer, plainBuffer];
 	wrappedKey[wrappedKeyBytes, wrappedKey];

--- a/BouncyCastle-JCA/src/CipherInputStream.crysl
+++ b/BouncyCastle-JCA/src/CipherInputStream.crysl
@@ -1,4 +1,5 @@
 SPEC javax.crypto.CipherInputStream
+
 OBJECTS
 	java.io.InputStream is;
 	javax.crypto.Cipher ciph;
@@ -23,6 +24,9 @@ ORDER
 
 CONSTRAINTS
 	len > off;
+	
+REQUIRES
+	generatedCipher[ciph];
 	
 ENSURES
 	cipheredInputStream[is, ciph];

--- a/BouncyCastle-JCA/src/CipherInputStream.crysl
+++ b/BouncyCastle-JCA/src/CipherInputStream.crysl
@@ -10,17 +10,17 @@ OBJECTS
 EVENTS
 	c1: CipherInputStream(is);
 	c2: CipherInputStream(is, ciph);
-	Constructs:= c1 | c2;
+	Cons:= c1 | c2;
 	
 	r1: read();
 	r2: read(b); 
 	r3: read(b, off, len);
 	Reads:= r1 | r2 | r3;
 	
-	c: close();
+	Close: close();
 	
 ORDER
-	Constructs, Reads+, c
+	Cons, Reads+, Close
 
 CONSTRAINTS
 	len > off;
@@ -30,3 +30,4 @@ REQUIRES
 	
 ENSURES
 	cipheredInputStream[is, ciph];
+	

--- a/BouncyCastle-JCA/src/CipherOutputStream.crysl
+++ b/BouncyCastle-JCA/src/CipherOutputStream.crysl
@@ -1,4 +1,5 @@
 SPEC javax.crypto.CipherOutputStream
+
 OBJECTS
 	java.io.OutputStream os;
 	javax.crypto.Cipher ciph;
@@ -24,6 +25,9 @@ ORDER
 	
 CONSTRAINTS
 	len > off;
+	
+REQUIRES
+	generatedCipher[ciph];
 	
 ENSURES
 	cipheredOutputStream[os, ciph];

--- a/BouncyCastle-JCA/src/CipherOutputStream.crysl
+++ b/BouncyCastle-JCA/src/CipherOutputStream.crysl
@@ -11,17 +11,17 @@ OBJECTS
 EVENTS
 	c1: CipherOutputStream(os);
 	c2: CipherOutputStream(os, ciph);
-	Constructs:= c1 | c2;
+	Cons:= c1 | c2;
 	
 	w1: write(b);
 	w2: write(byte);
 	w3: write(byte, off, len);
 	Writes:= w1 | w2 | w3;
 	
-	c: close();
+	Close: close();
 	
 ORDER
-	Constructs, Writes+, c
+	Cons, Writes+, Close
 	
 CONSTRAINTS
 	len > off;
@@ -31,3 +31,4 @@ REQUIRES
 	
 ENSURES
 	cipheredOutputStream[os, ciph];
+	

--- a/BouncyCastle-JCA/src/DHGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DHGenParameterSpec.crysl
@@ -5,10 +5,11 @@ OBJECTS
 	int exponentSize;
 	
 EVENTS
-	con: DHGenParameterSpec(primeSize, exponentSize);	
+	Con: DHGenParameterSpec(primeSize, exponentSize);	
 	
 ORDER
-	con
+	Con
 	
 ENSURES
 	preparedDH[this];
+	

--- a/BouncyCastle-JCA/src/DHGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DHGenParameterSpec.crysl
@@ -1,10 +1,14 @@
 SPEC javax.crypto.spec.DHGenParameterSpec
+
 OBJECTS 
 	int primeSize;
 	int exponentSize;
+	
 EVENTS
-	c1: DHGenParameterSpec(primeSize, exponentSize);	
+	con: DHGenParameterSpec(primeSize, exponentSize);	
+	
 ORDER
-	c1
+	con
+	
 ENSURES
 	preparedDH[this];

--- a/BouncyCastle-JCA/src/DHParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DHParameterSpec.crysl
@@ -1,8 +1,10 @@
 SPEC javax.crypto.spec.DHParameterSpec
+
 OBJECTS 
 	java.math.BigInteger p;
 	java.math.BigInteger g;
 	int l;
+	
 EVENTS
 	c1: DHParameterSpec(p, g);
 	c2: DHParameterSpec(p, g, l);

--- a/BouncyCastle-JCA/src/DHParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DHParameterSpec.crysl
@@ -19,3 +19,4 @@ CONSTRAINTS
 	
 ENSURES
 	preparedDH[this];
+	

--- a/BouncyCastle-JCA/src/DSAGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DSAGenParameterSpec.crysl
@@ -1,8 +1,10 @@
 SPEC java.security.spec.DSAGenParameterSpec
+
 OBJECTS 
 	int primePLen;
 	int subPrimeQLen;
 	int seedLen;
+	
 EVENTS
 	c1: DSAGenParameterSpec(primePLen, subPrimeQLen);
 	c2: DSAGenParameterSpec(primePLen, subPrimeQLen, seedLen);
@@ -10,5 +12,6 @@ EVENTS
 	
 ORDER
 	Cons
+	
 ENSURES
 	preparedDSA[this];

--- a/BouncyCastle-JCA/src/DSAGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DSAGenParameterSpec.crysl
@@ -15,3 +15,4 @@ ORDER
 	
 ENSURES
 	preparedDSA[this];
+	

--- a/BouncyCastle-JCA/src/DSAParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DSAParameterSpec.crysl
@@ -6,10 +6,10 @@ OBJECTS
 	java.math.BigInteger g;
 	
 EVENTS
-	con: DSAParameterSpec(p, q, g);
+	Con: DSAParameterSpec(p, q, g);
 	
 ORDER
-	con
+	Con
 	
 CONSTRAINTS
 	p >= 1^2048;
@@ -17,3 +17,4 @@ CONSTRAINTS
 	
 ENSURES
 	preparedDSA[this];
+	

--- a/BouncyCastle-JCA/src/DSAParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DSAParameterSpec.crysl
@@ -1,15 +1,19 @@
 SPEC java.security.spec.DSAParameterSpec
+
 OBJECTS 
 	java.math.BigInteger p;
 	java.math.BigInteger q;
 	java.math.BigInteger g;
+	
 EVENTS
-	c1: DSAParameterSpec(p, q, g);
+	con: DSAParameterSpec(p, q, g);
 	
 ORDER
-	c1
+	con
+	
 CONSTRAINTS
 	p >= 1^2048;
 	g >= 1^2048;
+	
 ENSURES
 	preparedDSA[this];

--- a/BouncyCastle-JCA/src/GCMParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/GCMParameterSpec.crysl
@@ -1,9 +1,11 @@
 SPEC javax.crypto.spec.GCMParameterSpec
+
 OBJECTS 
 	int tLen;
 	byte[] src;
 	int offset;
 	int len;
+	
 EVENTS
 	c1: GCMParameterSpec(tLen, src);
 	c2: GCMParameterSpec(tLen, src, offset, len);
@@ -11,10 +13,12 @@ EVENTS
 	
 ORDER
 	Cons
+	
 CONSTRAINTS
 	tLen in {96, 104, 112, 120, 128};
 	
 REQUIRES
 	randomized[src];
+	
 ENSURES
 	preparedGCM[this];

--- a/BouncyCastle-JCA/src/GCMParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/GCMParameterSpec.crysl
@@ -22,3 +22,4 @@ REQUIRES
 	
 ENSURES
 	preparedGCM[this];
+	

--- a/BouncyCastle-JCA/src/HMACParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/HMACParameterSpec.crysl
@@ -4,10 +4,11 @@ OBJECTS
 	int outputLength;
 	
 EVENTS
-	con: HMACParameterSpec(outputLength);
+	Con: HMACParameterSpec(outputLength);
 	
 ORDER
-	con
+	Con
 	
 ENSURES
 	preparedHMAC[this];
+	

--- a/BouncyCastle-JCA/src/HMACParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/HMACParameterSpec.crysl
@@ -1,10 +1,13 @@
 SPEC javax.xml.crypto.dsig.spec.HMACParameterSpec
+
 OBJECTS 
 	int outputLength;
+	
 EVENTS
-	c1: HMACParameterSpec(outputLength);
+	con: HMACParameterSpec(outputLength);
 	
 ORDER
-	c1
+	con
+	
 ENSURES
 	preparedHMAC[this];

--- a/BouncyCastle-JCA/src/IvParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/IvParameterSpec.crysl
@@ -1,8 +1,10 @@
 SPEC javax.crypto.spec.IvParameterSpec
+
 OBJECTS 
 	byte[] iv;
 	int offset;
 	int len;
+	
 EVENTS
 	cons1: IvParameterSpec(iv);
 	cons2: IvParameterSpec(iv, offset, len);
@@ -10,7 +12,9 @@ EVENTS
 	
 ORDER
 	Cons
+	
 REQUIRES
 	randomized[iv];
+	
 ENSURES
 	preparedIV[this];

--- a/BouncyCastle-JCA/src/IvParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/IvParameterSpec.crysl
@@ -18,3 +18,4 @@ REQUIRES
 	
 ENSURES
 	preparedIV[this];
+	

--- a/BouncyCastle-JCA/src/Key.crysl
+++ b/BouncyCastle-JCA/src/Key.crysl
@@ -4,10 +4,11 @@ OBJECTS
 	byte[] keyMaterial;
 	
 EVENTS
-	ge: keyMaterial = getEncoded();
+	GetEnc: keyMaterial = getEncoded();
 	
 ORDER
-	ge*
+	GetEnc*
 	
 ENSURES
-	preparedKeyMaterial[keyMaterial] after ge;
+	preparedKeyMaterial[keyMaterial] after GetEnc;
+	

--- a/BouncyCastle-JCA/src/Key.crysl
+++ b/BouncyCastle-JCA/src/Key.crysl
@@ -1,10 +1,13 @@
 SPEC java.security.Key
+
 OBJECTS 
-	java.security.Key key;
 	byte[] keyMaterial;
+	
 EVENTS
 	ge: keyMaterial = getEncoded();
+	
 ORDER
 	ge*
+	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after ge;

--- a/BouncyCastle-JCA/src/KeyAgreement.crysl
+++ b/BouncyCastle-JCA/src/KeyAgreement.crysl
@@ -20,15 +20,15 @@ EVENTS
     i4: init(key, random);
     Inits := i1 | i2 | i3 | i4;
     
-    dp: doPhase(key, lastPhase);
+    DoPhase: doPhase(key, lastPhase);
     
     gs1: generateSecret();
     gs2: generateSecret(sharedSecret, offset);
     gs3: generateSecret(algorithm);
-    GenSecret := gs1 | gs2 | gs3;
+    GenSecrets := gs1 | gs2 | gs3;
     
 ORDER
-	Gets, Inits, dp, GenSecret
+	Gets, Inits, DoPhase, GenSecrets
 	
 CONSTRAINTS
 	algorithm in {"DH", "DiffieHellman", "NH"};

--- a/BouncyCastle-JCA/src/KeyAgreement.crysl
+++ b/BouncyCastle-JCA/src/KeyAgreement.crysl
@@ -11,21 +11,21 @@ OBJECTS
 	
 EVENTS
 	g1: getInstance(algorithm);
-    g2: getInstance(algorithm, _);
-    Gets := g1 | g2;
+	g2: getInstance(algorithm, _);
+	Gets := g1 | g2;
     
-    i1: init(key);
-    i2: init(key, params);
-    i3: init(key, params, random);
-    i4: init(key, random);
-    Inits := i1 | i2 | i3 | i4;
+	i1: init(key);
+	i2: init(key, params);
+	i3: init(key, params, random);
+	i4: init(key, random);
+	Inits := i1 | i2 | i3 | i4;
     
-    DoPhase: doPhase(key, lastPhase);
+	DoPhase: doPhase(key, lastPhase);
     
-    gs1: generateSecret();
-    gs2: generateSecret(sharedSecret, offset);
-    gs3: generateSecret(algorithm);
-    GenSecrets := gs1 | gs2 | gs3;
+	gs1: generateSecret();
+	gs2: generateSecret(sharedSecret, offset);
+	gs3: generateSecret(algorithm);
+	GenSecrets := gs1 | gs2 | gs3;
     
 ORDER
 	Gets, Inits, DoPhase, GenSecrets
@@ -34,7 +34,7 @@ CONSTRAINTS
 	algorithm in {"DH", "DiffieHellman", "NH"};
 	
 REQUIRES
-    randomized[random];
+	randomized[random];
     
 ENSURES 
-    agreedKey[key, algorithm];
+	agreedKey[key, algorithm];

--- a/BouncyCastle-JCA/src/KeyAgreement.crysl
+++ b/BouncyCastle-JCA/src/KeyAgreement.crysl
@@ -1,4 +1,5 @@
 SPEC javax.crypto.KeyAgreement
+
 OBJECTS
 	java.lang.String algorithm;
 	java.security.Key key;
@@ -10,7 +11,7 @@ OBJECTS
 	
 EVENTS
 	g1: getInstance(algorithm);
-    g2:getInstance(algorithm, _);
+    g2: getInstance(algorithm, _);
     Gets := g1 | g2;
     
     i1: init(key);

--- a/BouncyCastle-JCA/src/KeyFactory.crysl
+++ b/BouncyCastle-JCA/src/KeyFactory.crysl
@@ -1,8 +1,10 @@
 SPEC java.security.KeyFactory
+
 OBJECTS
     java.lang.String keyFactoryAlgorithm;
-    java.security.Key key;
     java.security.spec.KeySpec keySpec;
+    java.security.PrivateKey privKey;
+    java.security.PublicKey pubKey;
    
 EVENTS
     g1: getInstance(keyFactoryAlgorithm);
@@ -12,14 +14,17 @@ EVENTS
     gPriv: generatePrivate(keySpec);
     gPubl: generatePublic(keySpec);
     
-    Gens := gPriv | gPubl;
-
 ORDER
-    Gets, Gens
+    Gets, (gPriv* | gPubl*)*
 
 CONSTRAINTS
 	keyFactoryAlgorithm in {"DiffieHellman", "DH", "DSA", "EC", "ECDH", "ECDHC", "ECDSA", "RSA", "ElGamal", "McElieceKobaraImai", 
 							"McEliecePointcheval", "McElieceFujisaki", "McEliece", "McEliece-CCA2", "NH", "QTESLA", "Rainbow", "SPHINCS256", "XMSS", "XMSSMT"};
 	
+REQUIRES
+	speccedKey[keySpec, _];	
+	
 ENSURES
-    generatedKeyFactory[key, keyFactoryAlgorithm];
+    generatedKeyFactory[this, keyFactoryAlgorithm] after Gets;
+    generatedPrivkey[privKey] after gPriv;
+    generatedPubkey[pubKey] after gPubl;

--- a/BouncyCastle-JCA/src/KeyFactory.crysl
+++ b/BouncyCastle-JCA/src/KeyFactory.crysl
@@ -1,31 +1,32 @@
 SPEC java.security.KeyFactory
 
 OBJECTS
-    java.lang.String keyFactoryAlgorithm;
-    java.security.spec.KeySpec keySpec;
-    java.security.PrivateKey privKey;
-    java.security.PublicKey pubKey;
+	java.lang.String keyFactoryAlgorithm;
+	java.security.spec.KeySpec keySpec;
+	java.security.PrivateKey privKey;
+	java.security.PublicKey pubKey;
    
 EVENTS
-    g1: getInstance(keyFactoryAlgorithm);
-    g2: getInstance(keyFactoryAlgorithm, _);
-    Gets := g1 | g2;
+	g1: getInstance(keyFactoryAlgorithm);
+	g2: getInstance(keyFactoryAlgorithm, _);
+	Gets := g1 | g2;
 
-    GenPriv: generatePrivate(keySpec);
-    GenPubl: generatePublic(keySpec);    
+	GenPriv: generatePrivate(keySpec);
+	GenPubl: generatePublic(keySpec);    
     
 ORDER
-    Gets, (GenPriv* | GenPubl*)*
+	Gets, (GenPriv* | GenPubl*)*
 
 CONSTRAINTS
-	keyFactoryAlgorithm in {"DiffieHellman", "DH", "DSA", "EC", "ECDH", "ECDHC", "ECDSA", "RSA", "ElGamal", "McElieceKobaraImai", 
-							"McEliecePointcheval", "McElieceFujisaki", "McEliece", "McEliece-CCA2", "NH", "QTESLA", "Rainbow", "SPHINCS256", "XMSS", "XMSSMT"};
+	keyFactoryAlgorithm in {"DiffieHellman", "DH", "DSA", "EC", "ECDH", "ECDHC", "ECDSA", "RSA", "ElGamal", 
+							"McElieceKobaraImai", "McEliecePointcheval", "McElieceFujisaki", "McEliece", "McEliece-CCA2", 
+							"NH", "QTESLA", "Rainbow", "SPHINCS256", "XMSS", "XMSSMT"};
 	
 REQUIRES
 	speccedKey[keySpec, _];	
 	
 ENSURES
-    generatedKeyFactory[this, keyFactoryAlgorithm] after Gets;
-    generatedPrivkey[privKey] after GenPriv;
-    generatedPubkey[pubKey] after GenPubl;
+	generatedKeyFactory[this, keyFactoryAlgorithm] after Gets;
+	generatedPrivkey[privKey] after GenPriv;
+	generatedPubkey[pubKey] after GenPubl;
     

--- a/BouncyCastle-JCA/src/KeyFactory.crysl
+++ b/BouncyCastle-JCA/src/KeyFactory.crysl
@@ -11,11 +11,11 @@ EVENTS
     g2: getInstance(keyFactoryAlgorithm, _);
     Gets := g1 | g2;
 
-    gPriv: generatePrivate(keySpec);
-    gPubl: generatePublic(keySpec);
+    GenPriv: generatePrivate(keySpec);
+    GenPubl: generatePublic(keySpec);    
     
 ORDER
-    Gets, (gPriv* | gPubl*)*
+    Gets, (GenPriv* | GenPubl*)*
 
 CONSTRAINTS
 	keyFactoryAlgorithm in {"DiffieHellman", "DH", "DSA", "EC", "ECDH", "ECDHC", "ECDSA", "RSA", "ElGamal", "McElieceKobaraImai", 
@@ -26,5 +26,6 @@ REQUIRES
 	
 ENSURES
     generatedKeyFactory[this, keyFactoryAlgorithm] after Gets;
-    generatedPrivkey[privKey] after gPriv;
-    generatedPubkey[pubKey] after gPubl;
+    generatedPrivkey[privKey] after GenPriv;
+    generatedPubkey[pubKey] after GenPubl;
+    

--- a/BouncyCastle-JCA/src/KeyGenerator.crysl
+++ b/BouncyCastle-JCA/src/KeyGenerator.crysl
@@ -1,4 +1,5 @@
 SPEC javax.crypto.KeyGenerator
+
 OBJECTS
     int secretKeySize;
     java.security.spec.AlgorithmParameterSpec params;

--- a/BouncyCastle-JCA/src/KeyGenerator.crysl
+++ b/BouncyCastle-JCA/src/KeyGenerator.crysl
@@ -1,40 +1,40 @@
 SPEC javax.crypto.KeyGenerator
 
 OBJECTS
-    int secretKeySize;
-    java.security.spec.AlgorithmParameterSpec params;
-    javax.crypto.SecretKey key;
-    java.lang.String secretKeyAlgorithm;
-    java.security.SecureRandom ranGen;
+	int secretKeySize;
+	java.security.spec.AlgorithmParameterSpec params;
+	javax.crypto.SecretKey key;
+	java.lang.String secretKeyAlgorithm;
+	java.security.SecureRandom ranGen;
 
 EVENTS
-    g1: getInstance(secretKeyAlgorithm);
-    g2: getInstance(secretKeyAlgorithm, _);
-    Gets := g1 | g2;
+	g1: getInstance(secretKeyAlgorithm);
+	g2: getInstance(secretKeyAlgorithm, _);
+	Gets := g1 | g2;
 
-    i1: init(secretKeySize);
-    i2: init(secretKeySize, ranGen);
-    i3: init(params);
-    i4: init(params, ranGen);
-    i5: init(ranGen);
-    Inits := i1 | i2 | i3 | i4 | i5;
+	i1: init(secretKeySize);
+	i2: init(secretKeySize, ranGen);
+	i3: init(params);
+	i4: init(params, ranGen);
+	i5: init(ranGen);
+	Inits := i1 | i2 | i3 | i4 | i5;
     
-    GenKey: key = generateKey();
+	GenKey: key = generateKey();
 
 ORDER
-    Gets, Inits?, GenKey
+	Gets, Inits?, GenKey
 
 CONSTRAINTS
 	secretKeyAlgorithm in {"AES", "HmacSHA224", "HmacSHA256", "HmacSHA384", "HmacSHA512", "Poly1305-AES", "Poly1305-Camellia", "Camellia", "ChaCha", 
 							"ChaCha7539", "Poly1305", "Rijndael", "Salsa20", "Serpent", "Tnepres", "Poly1305-Serpent", "SHACAL-2", "Shacal2", "Twofish", 
 							"Poly1305-Twofish", "XSalsa20"};
-    secretKeyAlgorithm in {"AES", "Poly1305-Camellia", "Camellia", "ChaCha", "Salsa20", "SHACAL-2", "Shacal2",
-    						"Rijndael", "Serpent", "Tnepres", "ChaCha7539", "Poly1305", "Poly1305-Serpent", 
-    						"Twofish", "Poly1305-Twofish", "XSalsa20"} => secretKeySize in {128, 192, 256};
+	secretKeyAlgorithm in {"AES", "Poly1305-Camellia", "Camellia", "ChaCha", "Salsa20", "SHACAL-2", "Shacal2",
+							"Rijndael", "Serpent", "Tnepres", "ChaCha7539", "Poly1305", "Poly1305-Serpent", 
+							"Twofish", "Poly1305-Twofish", "XSalsa20"} => secretKeySize in {128, 192, 256};
 
 REQUIRES
-    randomized[ranGen];
+	randomized[ranGen];
     
 ENSURES 
-    generatedKey[key, secretKeyAlgorithm];
+	generatedKey[key, secretKeyAlgorithm];
     

--- a/BouncyCastle-JCA/src/KeyGenerator.crysl
+++ b/BouncyCastle-JCA/src/KeyGenerator.crysl
@@ -19,10 +19,10 @@ EVENTS
     i5: init(ranGen);
     Inits := i1 | i2 | i3 | i4 | i5;
     
-    gk: key = generateKey();
+    GenKey: key = generateKey();
 
 ORDER
-    Gets, Inits?, gk
+    Gets, Inits?, GenKey
 
 CONSTRAINTS
 	secretKeyAlgorithm in {"AES", "HmacSHA224", "HmacSHA256", "HmacSHA384", "HmacSHA512", "Poly1305-AES", "Poly1305-Camellia", "Camellia", "ChaCha", 
@@ -37,3 +37,4 @@ REQUIRES
     
 ENSURES 
     generatedKey[key, secretKeyAlgorithm];
+    

--- a/BouncyCastle-JCA/src/KeyManagerFactory.crysl
+++ b/BouncyCastle-JCA/src/KeyManagerFactory.crysl
@@ -32,5 +32,5 @@ REQUIRES
 	
 ENSURES
 	generatedKeyManager[this] after Init;
-	generatedKeyManagers[kms];
+	generatedKeyManagers[kms] after GetKeyMng;
 	

--- a/BouncyCastle-JCA/src/KeyManagerFactory.crysl
+++ b/BouncyCastle-JCA/src/KeyManagerFactory.crysl
@@ -16,10 +16,10 @@ EVENTS
 	i2: init(params);
 	Init := i1 | i2;
 	
-	gkm: kms = getKeyManagers();
+	GetKeyMng: kms = getKeyManagers();
 			
 ORDER
-	Gets, Init, gkm?
+	Gets, Init, GetKeyMng?
 
 CONSTRAINTS
     neverTypeOf[password, java.lang.String];
@@ -32,4 +32,5 @@ REQUIRES
 	
 ENSURES
 	generatedKeyManager[this] after Init;
-	generatedKeyManager[kms];
+	generatedKeyManagers[kms];
+	

--- a/BouncyCastle-JCA/src/KeyManagerFactory.crysl
+++ b/BouncyCastle-JCA/src/KeyManagerFactory.crysl
@@ -1,8 +1,8 @@
 SPEC javax.net.ssl.KeyManagerFactory
 
 OBJECTS
-    char[] password;
-    java.lang.String algo;
+	char[] password;
+	java.lang.String algo;
 	java.security.KeyStore keyStore;
 	javax.net.ssl.ManagerFactoryParameters params;
 	javax.net.ssl.KeyManager[] kms;
@@ -22,9 +22,9 @@ ORDER
 	Gets, Init, GetKeyMng?
 
 CONSTRAINTS
-    neverTypeOf[password, java.lang.String];
-    notHardCoded[password];
-    algo in {"PKIX", "X509", "X.509"};
+	neverTypeOf[password, java.lang.String];
+	notHardCoded[password];
+	algo in {"PKIX", "X509", "X.509"};
 
 REQUIRES
 	generatedKeyStore[keyStore];

--- a/BouncyCastle-JCA/src/KeyManagerFactory.crysl
+++ b/BouncyCastle-JCA/src/KeyManagerFactory.crysl
@@ -23,10 +23,12 @@ ORDER
 
 CONSTRAINTS
     neverTypeOf[password, java.lang.String];
+    notHardCoded[password];
     algo in {"PKIX", "X509", "X.509"};
 
 REQUIRES
 	generatedKeyStore[keyStore];
+	generatedManagerFactoryParameters[params];
 	
 ENSURES
 	generatedKeyManager[this] after Init;

--- a/BouncyCastle-JCA/src/KeyPair.crysl
+++ b/BouncyCastle-JCA/src/KeyPair.crysl
@@ -7,18 +7,20 @@ OBJECTS
 	java.security.PublicKey retPub;
 	
 EVENTS
-	con: KeyPair(consPub, consPriv);
-	pu: retPub = getPublic();
-	pr: retPriv = getPrivate();
+	Con: KeyPair(consPub, consPriv);
+	
+	GetPubl: retPub = getPublic();
+	GetPriv: retPriv = getPrivate();
 
 ORDER
-	con, (pu*, pr*)*
+	Con, (GetPubl*, GetPriv*)*
 	
 REQUIRES
 	generatedPrivkey[consPriv];
 	generatedPubkey[consPub];
 	
 ENSURES
-	generatedKeypair[this, _] after con;
-	generatedPubkey[retPub] after pu;
-	generatedPrivkey[retPriv] after pr;
+	generatedKeypair[this, _] after Con;
+	generatedPubkey[retPub] after GetPubl;
+	generatedPrivkey[retPriv] after GetPriv;
+	

--- a/BouncyCastle-JCA/src/KeyPair.crysl
+++ b/BouncyCastle-JCA/src/KeyPair.crysl
@@ -1,26 +1,24 @@
 SPEC java.security.KeyPair
+
 OBJECTS
 	java.security.PrivateKey consPriv;
 	java.security.PublicKey consPub;
-	
 	java.security.PrivateKey retPriv;
 	java.security.PublicKey retPub;
 	
 EVENTS
-	co : KeyPair(consPub, consPriv);
-
-	pu : retPub = getPublic();
-	pr : retPriv = getPrivate();
-	Gets := pu | pr;
+	con: KeyPair(consPub, consPriv);
+	pu: retPub = getPublic();
+	pr: retPriv = getPrivate();
 
 ORDER
-	co?, (pu*, pr*)*
+	con, (pu*, pr*)*
 	
 REQUIRES
 	generatedPrivkey[consPriv];
 	generatedPubkey[consPub];
 	
 ENSURES
-	generatedKeypair[this, _] after co;
+	generatedKeypair[this, _] after con;
 	generatedPubkey[retPub] after pu;
 	generatedPrivkey[retPriv] after pr;

--- a/BouncyCastle-JCA/src/KeyPairGenerator.crysl
+++ b/BouncyCastle-JCA/src/KeyPairGenerator.crysl
@@ -1,45 +1,45 @@
 SPEC java.security.KeyPairGenerator
 
 OBJECTS
-    java.lang.String keyPairAlgorithm;
-    java.security.KeyPair kp;
-    java.security.spec.AlgorithmParameterSpec params;
-    int keyPairSize;
+	java.lang.String keyPairAlgorithm;
+	java.security.KeyPair kp;
+	java.security.spec.AlgorithmParameterSpec params;
+	int keyPairSize;
 
 EVENTS
-    g1:getInstance(keyPairAlgorithm);
-    g2:getInstance(keyPairAlgorithm, _);
-    Gets := g1 | g2;
+	g1:getInstance(keyPairAlgorithm);
+	g2:getInstance(keyPairAlgorithm, _);
+	Gets := g1 | g2;
 
 	i1: initialize(keyPairSize);
-    i2: initialize(keyPairSize, _);
-    i3: initialize(params);
-    i4: initialize(params, _);
-    Inits := i1 | i2 | i3 | i4;
+	i2: initialize(keyPairSize, _);
+	i3: initialize(params);
+	i4: initialize(params, _);
+	Inits := i1 | i2 | i3 | i4;
 
-    k1: kp = generateKeyPair();
-    k2: kp = genKeyPair();
-    Gens := k1 | k2;
+	k1: kp = generateKeyPair();
+	k2: kp = genKeyPair();
+	Gens := k1 | k2;
 
 ORDER
-    Gets, Inits, Gens
+	Gets, Inits, Gens
 
 CONSTRAINTS
 	keyPairAlgorithm in {"RSA", "DSA", "DiffieHellman", "DH", "EC", "ECDSA", "ECDH", "ECDHWITHSHA1KDF", "ECDHC", 
 						"ECIES", "ElGamal", "McElieceKobaraImai", "McEliecePointcheval", "McElieceFujisaki", 
 						"McEliece", "McEliece-CCA2", "NH", "QTESLA", "Rainbow", "SPHINCS256", "XMSS", "XMSSMT"};
 						
-    keyPairAlgorithm in {"RSA"} => keyPairSize in {4096, 3072, 2048};
-    keyPairAlgorithm in {"DSA"} => keyPairSize in {2048};
+	keyPairAlgorithm in {"RSA"} => keyPairSize in {4096, 3072, 2048};
+	keyPairAlgorithm in {"DSA"} => keyPairSize in {2048};
 	keyPairAlgorithm in {"DiffieHellman", "DH"} => keyPairSize in {2048};
 	keyPairAlgorithm in {"EC", "ECDSA", "ECDH", "ECDHWITHSHA1KDF", "ECDHC", "ECIES"} => keyPairSize in {256};
 	
 REQUIRES
-    keyPairAlgorithm in {"RSA"} => preparedRSA[params];
-    keyPairAlgorithm in {"DSA"} => preparedDSA[params];
-    keyPairAlgorithm in {"DiffieHellman", "DH"} => preparedDH[params];
-    keyPairAlgorithm in {"EC"} => preparedEC[params];
+	keyPairAlgorithm in {"RSA"} => preparedRSA[params];
+	keyPairAlgorithm in {"DSA"} => preparedDSA[params];
+	keyPairAlgorithm in {"DiffieHellman", "DH"} => preparedDH[params];
+	keyPairAlgorithm in {"EC"} => preparedEC[params];
 
 ENSURES
-    generatedKeypair[kp, keyPairAlgorithm];
+	generatedKeypair[kp, keyPairAlgorithm];
     

--- a/BouncyCastle-JCA/src/KeyPairGenerator.crysl
+++ b/BouncyCastle-JCA/src/KeyPairGenerator.crysl
@@ -19,10 +19,10 @@ EVENTS
 
     k1: kp = generateKeyPair();
     k2: kp = genKeyPair();
-    Generators := k1 | k2;
+    Gens := k1 | k2;
 
 ORDER
-    Gets, Inits, Generators
+    Gets, Inits, Gens
 
 CONSTRAINTS
 	keyPairAlgorithm in {"RSA", "DSA", "DiffieHellman", "DH", "EC", "ECDSA", "ECDH", "ECDHWITHSHA1KDF", "ECDHC", 
@@ -39,7 +39,7 @@ REQUIRES
     keyPairAlgorithm in {"DSA"} => preparedDSA[params];
     keyPairAlgorithm in {"DiffieHellman", "DH"} => preparedDH[params];
     keyPairAlgorithm in {"EC"} => preparedEC[params];
-    
 
 ENSURES
     generatedKeypair[kp, keyPairAlgorithm];
+    

--- a/BouncyCastle-JCA/src/KeyPairGenerator.crysl
+++ b/BouncyCastle-JCA/src/KeyPairGenerator.crysl
@@ -1,4 +1,5 @@
 SPEC java.security.KeyPairGenerator
+
 OBJECTS
     java.lang.String keyPairAlgorithm;
     java.security.KeyPair kp;
@@ -37,7 +38,7 @@ REQUIRES
     keyPairAlgorithm in {"RSA"} => preparedRSA[params];
     keyPairAlgorithm in {"DSA"} => preparedDSA[params];
     keyPairAlgorithm in {"DiffieHellman", "DH"} => preparedDH[params];
-    keyPairAlgorithm in {"EC"} => preparedEC[params]; //seems missing
+    keyPairAlgorithm in {"EC"} => preparedEC[params];
     
 
 ENSURES

--- a/BouncyCastle-JCA/src/KeyStore.crysl
+++ b/BouncyCastle-JCA/src/KeyStore.crysl
@@ -1,57 +1,57 @@
 SPEC java.security.KeyStore 
 
 OBJECTS
-    java.io.InputStream fileinput;
+	java.io.InputStream fileinput;
     
-    char[] passwordIn;
-    char[] passwordOut;
-    char[] passwordKey;
+	char[] passwordIn;
+	char[] passwordOut;
+	char[] passwordKey;
     
-    java.security.KeyStore.Entry entry;
-    byte[] byteKey;
+	java.security.KeyStore.Entry entry;
+	byte[] byteKey;
     
-    java.security.KeyStore.LoadStoreParameter paramLoad;
-    java.security.KeyStore.ProtectionParameter protParamGet;
-    java.security.KeyStore.ProtectionParameter protParamSet;
-    java.lang.String aliasGet;
-    java.lang.String aliasSet;
-    java.io.OutputStream fileoutput;
-    java.security.KeyStore.LoadStoreParameter paramStore;
-    java.lang.String keyStoreAlgorithm;
-    java.security.cert.Certificate[] chain;
-    java.security.cert.Certificate cert;
+	java.security.KeyStore.LoadStoreParameter paramLoad;
+	java.security.KeyStore.ProtectionParameter protParamGet;
+	java.security.KeyStore.ProtectionParameter protParamSet;
+	java.lang.String aliasGet;
+	java.lang.String aliasSet;
+	java.io.OutputStream fileoutput;
+	java.security.KeyStore.LoadStoreParameter paramStore;
+	java.lang.String keyStoreAlgorithm;
+	java.security.cert.Certificate[] chain;
+	java.security.cert.Certificate cert;
     
-    java.security.Key key;
-    java.lang.String alias;
+	java.security.Key key;
+	java.lang.String alias;
     
 EVENTS
-    g1: getInstance(keyStoreAlgorithm);
-    g2: getInstance(keyStoreAlgorithm, _);
-    Gets := g1 | g2;
+	g1: getInstance(keyStoreAlgorithm);
+	g2: getInstance(keyStoreAlgorithm, _);
+	Gets := g1 | g2;
 
-    l1: load(fileinput, passwordIn);
-    l2: load(paramLoad);
-    Loads := l1 | l2;
+	l1: load(fileinput, passwordIn);
+	l2: load(paramLoad);
+	Loads := l1 | l2;
 
-    s1:store(paramStore);
-    s2:store(fileoutput, passwordOut);
-    Stores := s1 | s2;
+	s1:store(paramStore);
+	s2:store(fileoutput, passwordOut);
+	Stores := s1 | s2;
 
-    GetEntry: getEntry(aliasGet, protParamGet);
+	GetEntry: getEntry(aliasGet, protParamGet);
     
-    SetEntry: setEntry(aliasSet, entry, protParamSet);
+	SetEntry: setEntry(aliasSet, entry, protParamSet);
         
-    GetKey: key = getKey(alias, passwordKey);
+	GetKey: key = getKey(alias, passwordKey);
 
 ORDER
-    Gets, Loads, ((GetEntry?, GetKey) | (SetEntry, Stores))*
+	Gets, Loads, ((GetEntry?, GetKey) | (SetEntry, Stores))*
 
 CONSTRAINTS
 	keyStoreAlgorithm in {"BCFKS", "BCFKS-DEF", "IBCFKS", "IBCFKS-DEF"};
-    neverTypeOf[passwordIn, java.lang.String];
-    neverTypeOf[passwordOut, java.lang.String];
-    neverTypeOf[passwordKey, java.lang.String];
-    notHardCoded[passwordIn];
+	neverTypeOf[passwordIn, java.lang.String];
+	neverTypeOf[passwordOut, java.lang.String];
+	neverTypeOf[passwordKey, java.lang.String];
+	notHardCoded[passwordIn];
 
 ENSURES
 	generatedKeyStore[this] after Loads;

--- a/BouncyCastle-JCA/src/KeyStore.crysl
+++ b/BouncyCastle-JCA/src/KeyStore.crysl
@@ -51,11 +51,10 @@ ORDER
 
 CONSTRAINTS
 	keyStoreAlgorithm in {"BCFKS", "BCFKS-DEF", "IBCFKS", "IBCFKS-DEF"};
-	
     neverTypeOf[passwordIn, java.lang.String];
     neverTypeOf[passwordOut, java.lang.String];
     neverTypeOf[passwordKey, java.lang.String];
-    notHardCoded[passwordIn] ;
+    notHardCoded[passwordIn];
 
 ENSURES
 	generatedKeyStore[this] after Loads;

--- a/BouncyCastle-JCA/src/KeyStore.crysl
+++ b/BouncyCastle-JCA/src/KeyStore.crysl
@@ -1,4 +1,5 @@
 SPEC java.security.KeyStore 
+
 OBJECTS
     java.io.InputStream fileinput;
     
@@ -36,18 +37,14 @@ EVENTS
     s2:store(fileoutput, passwordOut);
     Stores := s1 | s2;
 
-    gE: getEntry(aliasGet, protParamGet);
-    sE: setEntry(aliasSet, entry, protParamSet);
-    scE: setCertificateEntry(alias, cert);
-    skE1: setKeyEntry(alias, byteKey, chain);
-    skE2: setKeyEntry(alias, key, passwordKey, chain);
+    GetEntry: getEntry(aliasGet, protParamGet);
     
-    Entries := gE | sE | scE | skE1 | skE2;
-    
-    gk: key = getKey(alias, passwordKey);
+    SetEntry: setEntry(aliasSet, entry, protParamSet);
+        
+    GetKey: key = getKey(alias, passwordKey);
 
 ORDER
-    Gets, Loads, ((gE?, gk) | (sE, Stores))*
+    Gets, Loads, ((GetEntry?, GetKey) | (SetEntry, Stores))*
 
 CONSTRAINTS
 	keyStoreAlgorithm in {"BCFKS", "BCFKS-DEF", "IBCFKS", "IBCFKS-DEF"};
@@ -61,3 +58,4 @@ ENSURES
 	generatedKey[key, _];
 	generatedPrivkey[key];
 	generatedPubkey[key];
+	

--- a/BouncyCastle-JCA/src/KeyStoreBuilderParameters.crysl
+++ b/BouncyCastle-JCA/src/KeyStoreBuilderParameters.crysl
@@ -4,10 +4,10 @@ OBJECTS
 	java.security.KeyStore.Builder builder;
 	
 EVENTS
-	C: KeyStoreBuilderParameters(builder);
+	c: KeyStoreBuilderParameters(builder);
 	
 ORDER
-	C
+	c
 	
 ENSURES
 	generatedManagerFactoryParameters[this];

--- a/BouncyCastle-JCA/src/KeyStoreBuilderParameters.crysl
+++ b/BouncyCastle-JCA/src/KeyStoreBuilderParameters.crysl
@@ -4,10 +4,11 @@ OBJECTS
 	java.security.KeyStore.Builder builder;
 	
 EVENTS
-	c: KeyStoreBuilderParameters(builder);
+	Con: KeyStoreBuilderParameters(builder);
 	
 ORDER
-	c
+	Con
 	
 ENSURES
 	generatedManagerFactoryParameters[this];
+	

--- a/BouncyCastle-JCA/src/Mac.crysl
+++ b/BouncyCastle-JCA/src/Mac.crysl
@@ -1,4 +1,5 @@
 SPEC javax.crypto.Mac
+
 OBJECTS
     javax.crypto.Mac mac;
     java.security.Key key;
@@ -47,6 +48,7 @@ REQUIRES
     !encrypted[output1, _];
     !encrypted[output2,_];
     preparedHMAC[params];
+    generatedKey[key,_];
 
 ENSURES
     macced[output1, inp];

--- a/BouncyCastle-JCA/src/Mac.crysl
+++ b/BouncyCastle-JCA/src/Mac.crysl
@@ -1,56 +1,56 @@
 SPEC javax.crypto.Mac
 
 OBJECTS
-    javax.crypto.Mac mac;
-    java.security.Key key;
-    byte inp;
-    byte[] pre_input;
-    byte[] input;
-    byte[] output1;
-    byte[] output2;
-    java.lang.String macAlgorithm;
-    java.security.spec.AlgorithmParameterSpec params;
-    int offset;
-    int outOffset;
-    int len;
+	javax.crypto.Mac mac;
+	java.security.Key key;
+	byte inp;
+	byte[] pre_input;
+	byte[] input;
+	byte[] output1;
+	byte[] output2;
+	java.lang.String macAlgorithm;
+	java.security.spec.AlgorithmParameterSpec params;
+	int offset;
+	int outOffset;
+	int len;
 
 EVENTS
-    g1: getInstance(macAlgorithm);
-    g2: getInstance(macAlgorithm);
-    Gets := g1 | g2;
+	g1: getInstance(macAlgorithm);
+	g2: getInstance(macAlgorithm);
+	Gets := g1 | g2;
 
-    i1: init(key);
-    i2: init(key, params);
-    Inits := i1 | i2;
+	i1: init(key);
+	i2: init(key, params);
+	Inits := i1 | i2;
 
-    u1: update(inp);
-    u2: update(pre_input);
-    u3: update(pre_input, offset, len);
-    u4: update(pre_input);
-    Updates := u1 | u2 | u3 | u4;
+	u1: update(inp);
+	u2: update(pre_input);
+	u3: update(pre_input, offset, len);
+	u4: update(pre_input);
+	Updates := u1 | u2 | u3 | u4;
 
-    f1: output1 = doFinal();
-    f2: output2 = doFinal(input);
-    f3: doFinal(output1, outOffset);
-    FinalsWU := f1 | f3;
-    Finals := FinalsWU | f2;
+	f1: output1 = doFinal();
+	f2: output2 = doFinal(input);
+	f3: doFinal(output1, outOffset);
+	FinalsWU := f1 | f3;
+	Finals := FinalsWU | f2;
 
 ORDER
-    Gets, Inits, (FinalsWU | (Updates+, Finals))
+	Gets, Inits, (FinalsWU | (Updates+, Finals))
 
 CONSTRAINTS
-    macAlgorithm in {"AESCMAC", "AESCCMMAC", "HmacSHA256", "HmacSHA384", "HmacSHA512", "PBEWithHmacSHA256", "PBEWithHmacSHA384", 
-    					"PBEWithHmacSHA512", "Poly1305", "Shacal-2CMAC"};
-    offset < len;
-    length[output1] > outOffset;
+	macAlgorithm in {"AESCMAC", "AESCCMMAC", "HmacSHA256", "HmacSHA384", "HmacSHA512", "PBEWithHmacSHA256", "PBEWithHmacSHA384", 
+					"PBEWithHmacSHA512", "Poly1305", "Shacal-2CMAC"};
+	offset < len;
+	length[output1] > outOffset;
     
 REQUIRES
-    !encrypted[output1, _];
-    !encrypted[output2,_];
-    preparedHMAC[params];
-    generatedKey[key,_];
+	!encrypted[output1, _];
+	!encrypted[output2,_];
+	preparedHMAC[params];
+	generatedKey[key,_];
 
 ENSURES
-    macced[output1, inp];
-    macced[output1, pre_input];
-    macced[output2, input];
+	macced[output1, inp];
+	macced[output1, pre_input];
+	macced[output2, input];

--- a/BouncyCastle-JCA/src/MessageDigest.crysl
+++ b/BouncyCastle-JCA/src/MessageDigest.crysl
@@ -1,4 +1,5 @@
 SPEC java.security.MessageDigest
+
 OBJECTS
     java.lang.String digestAlgorithm;
     byte pre_inbyte;
@@ -39,5 +40,6 @@ CONSTRAINTS
     length[out] >= len + off;
 
 ENSURES
+	generatedMessageDigest[this] after Gets;
 	digested[out, _];
     digested[out, inbytearr];

--- a/BouncyCastle-JCA/src/MessageDigest.crysl
+++ b/BouncyCastle-JCA/src/MessageDigest.crysl
@@ -1,45 +1,45 @@
 SPEC java.security.MessageDigest
 
 OBJECTS
-    java.lang.String digestAlgorithm;
-    byte pre_inbyte;
-    byte[] pre_inbytearr;
-    int pre_off;
-    int pre_len;
-    java.nio.ByteBuffer pre_inpBuf;
-    byte[] inbytearr;
-    int off;
-    int len;
-    byte[] out;
+	java.lang.String digestAlgorithm;
+	byte pre_inbyte;
+	byte[] pre_inbytearr;
+	int pre_off;
+	int pre_len;
+	java.nio.ByteBuffer pre_inpBuf;
+	byte[] inbytearr;
+	int off;
+	int len;
+	byte[] out;
 	
 EVENTS
-    g1: getInstance(digestAlgorithm);
-    g2: getInstance(digestAlgorithm, _);
-    Gets := g1 | g2;
+	g1: getInstance(digestAlgorithm);
+	g2: getInstance(digestAlgorithm, _);
+	Gets := g1 | g2;
 
-    u1: update(pre_inbyte);
-    u2: update(pre_inbytearr);
-    u3: update(pre_inbytearr, pre_off, pre_len);
-    u4: update(pre_inpBuf);
-    Updates := u1 | u2 | u3 | u4;
+	u1: update(pre_inbyte);
+	u2: update(pre_inbytearr);
+	u3: update(pre_inbytearr, pre_off, pre_len);
+	u4: update(pre_inpBuf);
+	Updates := u1 | u2 | u3 | u4;
 
-    d1: out = digest();
-    d2: out = digest(inbytearr);
-    d3: digest(out, off, len);
-    DWOU := d2;
-    DWU := d1 | d3;
-    Digests := DWU | DWOU;
+	d1: out = digest();
+	d2: out = digest(inbytearr);
+	d3: digest(out, off, len);
+	DWOU := d2;
+	DWU := d1 | d3;
+	Digests := DWU | DWOU;
 
 ORDER
-    Gets, (DWOU | (Updates+, Digests))+
+	Gets, (DWOU | (Updates+, Digests))+
 
 CONSTRAINTS
-    digestAlgorithm in {"SHA-256", "SHA-384", "SHA-512", "SHA-512/256", "BLAKE2B-256", "BLAKE2B-384", "BLAKE2B-512",
-    					"BLAKE2S-256", "KECCAK-256", "KECCAK-384", "KECCAK-512", "WHIRLPOOL"};
-    length[pre_inbytearr] >= pre_len + pre_off;
-    length[out] >= len + off;
+	digestAlgorithm in {"SHA-256", "SHA-384", "SHA-512", "SHA-512/256", "BLAKE2B-256", "BLAKE2B-384", "BLAKE2B-512",
+						"BLAKE2S-256", "KECCAK-256", "KECCAK-384", "KECCAK-512", "WHIRLPOOL"};
+	length[pre_inbytearr] >= pre_len + pre_off;
+	length[out] >= len + off;
 
 ENSURES
 	generatedMessageDigest[this] after Gets;
 	digested[out, _];
-    digested[out, inbytearr];
+	digested[out, inbytearr];

--- a/BouncyCastle-JCA/src/PBEKeySpec.crysl
+++ b/BouncyCastle-JCA/src/PBEKeySpec.crysl
@@ -1,20 +1,22 @@
 SPEC javax.crypto.spec.PBEKeySpec
+
 OBJECTS 
 	char[] password;
 	byte[] salt;
 	int iterationCount;
 	int keylength; 
+	
 FORBIDDEN
-	PBEKeySpec(char[]) => c1;
-	PBEKeySpec(char[],byte[],int) => c1;
+	PBEKeySpec(char[]) => con;
+	PBEKeySpec(char[],byte[],int) => con;
 	
 EVENTS
-	c1: PBEKeySpec(password, salt, iterationCount, keylength);
-	
-	cP: clearPassword();
+	con: PBEKeySpec(password, salt, iterationCount, keylength);
+	clear: clearPassword();
 	
 ORDER
- 	c1,  cP
+ 	con,  clear
+ 	
 CONSTRAINTS
 	iterationCount >= 10000;
 	neverTypeOf[password, java.lang.String];
@@ -22,7 +24,9 @@ CONSTRAINTS
 
 REQUIRES
 	randomized[salt];	
+	
 ENSURES
-	speccedKey[this, keylength] after c1;
+	speccedKey[this, keylength] after con;
+	
 NEGATES
-	speccedKey[this, _] after cP;
+	speccedKey[this, _] after clear;

--- a/BouncyCastle-JCA/src/PBEKeySpec.crysl
+++ b/BouncyCastle-JCA/src/PBEKeySpec.crysl
@@ -7,15 +7,15 @@ OBJECTS
 	int keylength; 
 	
 FORBIDDEN
-	PBEKeySpec(char[]) => con;
-	PBEKeySpec(char[],byte[],int) => con;
+	PBEKeySpec(char[]) => Con;
+	PBEKeySpec(char[],byte[],int) => Con;
 	
 EVENTS
-	con: PBEKeySpec(password, salt, iterationCount, keylength);
-	clear: clearPassword();
+	Con: PBEKeySpec(password, salt, iterationCount, keylength);
+	ClearPass: clearPassword();
 	
 ORDER
- 	con,  clear
+ 	Con, ClearPass
  	
 CONSTRAINTS
 	iterationCount >= 10000;
@@ -26,7 +26,8 @@ REQUIRES
 	randomized[salt];	
 	
 ENSURES
-	speccedKey[this, keylength] after con;
+	speccedKey[this, keylength] after Con;
 	
 NEGATES
-	speccedKey[this, _] after clear;
+	speccedKey[this, _] after ClearPass;
+	

--- a/BouncyCastle-JCA/src/PBEParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/PBEParameterSpec.crysl
@@ -21,3 +21,4 @@ REQUIRES
 
 ENSURES
 	preparedPBE[this];
+	

--- a/BouncyCastle-JCA/src/PBEParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/PBEParameterSpec.crysl
@@ -1,4 +1,5 @@
 SPEC javax.crypto.spec.PBEParameterSpec
+
 OBJECTS 
 	byte[] salt;
 	int iterationCount;
@@ -11,6 +12,7 @@ EVENTS
 	
 ORDER
 	Cons
+	
 CONSTRAINTS
 	iterationCount >= 10000;	
 

--- a/BouncyCastle-JCA/src/PKIXBuilderParameters.crysl
+++ b/BouncyCastle-JCA/src/PKIXBuilderParameters.crysl
@@ -15,7 +15,7 @@ ORDER
 	
 REQUIRES
 	generatedKeyStore[keyStore];
-	//generatedTrustAnchor[];							
 	
 ENSURES
 	generatedCertPathParameters[this];
+	

--- a/BouncyCastle-JCA/src/PKIXBuilderParameters.crysl
+++ b/BouncyCastle-JCA/src/PKIXBuilderParameters.crysl
@@ -8,9 +8,10 @@ OBJECTS
 EVENTS
 	c1: PKIXBuilderParameters(keyStore, certSelector);
 	c2: PKIXBuilderParameters(trustAnchors, certSelector);
+	Cons := c1 | c2;
 	
 ORDER
-	c1 | c2
+	Cons
 	
 REQUIRES
 	generatedKeyStore[keyStore];

--- a/BouncyCastle-JCA/src/PKIXParameters.crysl
+++ b/BouncyCastle-JCA/src/PKIXParameters.crysl
@@ -2,16 +2,17 @@ SPEC java.security.cert.PKIXParameters
 
 OBJECTS
 	java.security.KeyStore keyStore;
-	java.util.Set<java.security.cert.TrustAnchor> trustAnchors;
 	
 EVENTS
 	c1: PKIXParameters(keyStore);
-	c2: PKIXParameters(trustAnchors);
+	c2: PKIXParameters(_);
+	Cons := c1 | c2;
+	
 ORDER
-	c1
+	Cons
 
 REQUIRES
 	generatedKeyStore[keyStore];		
-	//generatedTrustAnchor[];							
+							
 ENSURES
 	generatedCertPathParameters[this];

--- a/BouncyCastle-JCA/src/PKIXParameters.crysl
+++ b/BouncyCastle-JCA/src/PKIXParameters.crysl
@@ -16,3 +16,4 @@ REQUIRES
 							
 ENSURES
 	generatedCertPathParameters[this];
+	

--- a/BouncyCastle-JCA/src/RSAKeyGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/RSAKeyGenParameterSpec.crysl
@@ -5,10 +5,10 @@ OBJECTS
 	java.math.BigInteger publicExponent;
 	
 EVENTS
-	con: RSAKeyGenParameterSpec(keyLength, publicExponent);
+	Con: RSAKeyGenParameterSpec(keyLength, publicExponent);
 	
 ORDER
-	con
+	Con
 	
 CONSTRAINTS
 	 keyLength in {1024, 2048, 4096};
@@ -16,3 +16,4 @@ CONSTRAINTS
 	 
 ENSURES
 	preparedRSA[this];
+	

--- a/BouncyCastle-JCA/src/RSAKeyGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/RSAKeyGenParameterSpec.crysl
@@ -11,8 +11,8 @@ ORDER
 	Con
 	
 CONSTRAINTS
-	 keyLength in {1024, 2048, 4096};
-	 publicExponent in {65537};
+	keyLength in {1024, 2048, 4096};
+	publicExponent in {65537};
 	 
 ENSURES
 	preparedRSA[this];

--- a/BouncyCastle-JCA/src/RSAKeyGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/RSAKeyGenParameterSpec.crysl
@@ -1,14 +1,18 @@
 SPEC java.security.spec.RSAKeyGenParameterSpec
+
 OBJECTS 
 	int keyLength;
 	java.math.BigInteger publicExponent;
+	
 EVENTS
-	c1: RSAKeyGenParameterSpec(keyLength, publicExponent);
+	con: RSAKeyGenParameterSpec(keyLength, publicExponent);
 	
 ORDER
-	c1
+	con
+	
 CONSTRAINTS
 	 keyLength in {1024, 2048, 4096};
 	 publicExponent in {65537};
+	 
 ENSURES
 	preparedRSA[this];

--- a/BouncyCastle-JCA/src/SSLContext.crysl
+++ b/BouncyCastle-JCA/src/SSLContext.crysl
@@ -34,5 +34,5 @@ REQUIRES
 	
 ENSURES
 	generatedSSLContext[this] after Init;
-	generatedSSLEngine[eng];
+	generatedSSLEngine[eng] after Engines;
 	

--- a/BouncyCastle-JCA/src/SSLContext.crysl
+++ b/BouncyCastle-JCA/src/SSLContext.crysl
@@ -19,10 +19,10 @@ EVENTS
 	
 	se1: eng = createSSLEngine();
 	se2: eng = createSSLEngine(_,_);
-	Engine := se1 | se2;
+	Engines := se1 | se2;
 
 ORDER
-	Gets, Init, Engine? 
+	Gets, Init, Engines? 
 
 CONSTRAINTS
 	protocol in {"TLSv1.2"};
@@ -35,3 +35,4 @@ REQUIRES
 ENSURES
 	generatedSSLContext[this] after Init;
 	generatedSSLEngine[eng];
+	

--- a/BouncyCastle-JCA/src/SSLContext.crysl
+++ b/BouncyCastle-JCA/src/SSLContext.crysl
@@ -28,8 +28,8 @@ CONSTRAINTS
 	protocol in {"TLSv1.2"};
 
 REQUIRES
-	generatedKeyManager[kms];
-	generatedTrustManager[tms];
+	generatedKeyManagers[kms];
+	generatedTrustManagers[tms];
 	randomized[sr];
 	
 ENSURES

--- a/BouncyCastle-JCA/src/SSLEngine.crysl
+++ b/BouncyCastle-JCA/src/SSLEngine.crysl
@@ -1,43 +1,18 @@
 SPEC javax.net.ssl.SSLEngine
 
-/*
- *  When using raw SSLSocket and SSLEngine classes, 
- *  you should always check the peer's credentials
- *  before sending any data. The SSLSocket and SSLEngine 
- *  classes do not automatically verify that the host name
- *  in a URL matches the host name in the peer's credentials.
- *  An application could be exploited with URL spoofing if
- *  the host name is not verified. Since JDK 7, endpoint 
- *  identification/verification procedures can be handled 
- *  during SSL/TLS handshaking. See the SSLParameters.getEndpointIdentificationAlgorithm method.
- */
-
 OBJECTS
 	java.lang.String[] ciphersuites;
 	java.lang.String[] protocols;
+	
 EVENTS
-	
-	c1: SSLEngine();
-	c2: SSLEngine(_,_);
-	Con := c1 | c2;
-
 	ec: setEnabledCipherSuites(ciphersuites);
-	SetEnabledCipherSuites := ec;
-	
 	ep: setEnabledProtocols(protocols);
-	SetEnabledProtocols := ep;
-	
-	
-	/*	dependent on purpose of the SSLEngine obj (Client || Server)
-	 *  serverEngine.setUseClientMode(false);
-     *  serverEngine.setNeedClientAuth(true);
-	 */
 	
 ORDER
-	Con, (ec,ep) | (ep,ec) 
+	(ec,ep) | (ep,ec) 
 
 CONSTRAINTS
-	elements(protocols) in {"TLSv1.2","TLSv1.1"};
+	elements(protocols) in {"TLSv1.2"};
 	elements(ciphersuites) in {"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
 							"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 							"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",

--- a/BouncyCastle-JCA/src/SSLEngine.crysl
+++ b/BouncyCastle-JCA/src/SSLEngine.crysl
@@ -5,11 +5,12 @@ OBJECTS
 	java.lang.String[] protocols;
 	
 EVENTS
-	ec: setEnabledCipherSuites(ciphersuites);
-	ep: setEnabledProtocols(protocols);
+	EnableCipher: setEnabledCipherSuites(ciphersuites);
+	
+	EnableProtocol: setEnabledProtocols(protocols);
 	
 ORDER
-	(ec,ep) | (ep,ec) 
+	(EnableCipher, EnableProtocol) | (EnableProtocol, EnableCipher) 
 
 CONSTRAINTS
 	elements(protocols) in {"TLSv1.2"};
@@ -44,3 +45,4 @@ CONSTRAINTS
 		
 ENSURES
 	generatedSSLEngine[this];
+	

--- a/BouncyCastle-JCA/src/SSLParameters.crysl
+++ b/BouncyCastle-JCA/src/SSLParameters.crysl
@@ -1,7 +1,5 @@
 SPEC javax.net.ssl.SSLParameters
 
-/* Used for sslSocket */
-
 OBJECTS
 	java.lang.String[] ciphersuites;
 	java.lang.String[] protocols;
@@ -16,12 +14,10 @@ EVENTS
 		
 	
 ORDER
-	(C1, (CS , PR) | (PR , CS)) | (C2, PR) | C3
-	
-/* SSLParameters.setUseCipherSuitesOrder(true).*/
-	
+	(C1, ((CS , PR) | (PR , CS))) | (C2, PR) | C3
+		
 CONSTRAINTS
-	elements(protocols) in {"TLSv1.2","TLSv1.1"};
+	elements(protocols) in {"TLSv1.2"};
 	elements(ciphersuites) in {"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
 							"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 							"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",

--- a/BouncyCastle-JCA/src/SSLParameters.crysl
+++ b/BouncyCastle-JCA/src/SSLParameters.crysl
@@ -5,16 +5,16 @@ OBJECTS
 	java.lang.String[] protocols;
 	
 EVENTS
-	C1: SSLParameters();
-	C2: SSLParameters(ciphersuites);
-	C3: SSLParameters(ciphersuites,protocols);
+	Con1: SSLParameters();
+	Con2: SSLParameters(ciphersuites);
+	Con3: SSLParameters(ciphersuites,protocols);
 	
-	CS: setCipherSuites(ciphersuites);
-	PR:	setProtocols(protocols);
+	CipherSuite: setCipherSuites(ciphersuites);
+	SetProtocol: setProtocols(protocols);
 		
 	
 ORDER
-	(C1, ((CS , PR) | (PR , CS))) | (C2, PR) | C3
+	(Con1, ((CipherSuite , SetProtocol) | (SetProtocol , CipherSuite))) | (Con2, SetProtocol) | Con3
 		
 CONSTRAINTS
 	elements(protocols) in {"TLSv1.2"};
@@ -49,3 +49,4 @@ CONSTRAINTS
 				
 ENSURES
 	generatedSSLParameters[this];
+	

--- a/BouncyCastle-JCA/src/SecretKey.crysl
+++ b/BouncyCastle-JCA/src/SecretKey.crysl
@@ -1,13 +1,18 @@
 SPEC javax.crypto.SecretKey
+
 OBJECTS 
 	javax.crypto.SecretKey key;
 	byte[] keyMaterial;
+	
 EVENTS
-	d: destroy();
 	ge: keyMaterial = getEncoded();
+	d: destroy();
+	
 ORDER
 	ge*, d?
+	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after ge;
+	
 NEGATES
 	generatedKey[this, _] after d;

--- a/BouncyCastle-JCA/src/SecretKey.crysl
+++ b/BouncyCastle-JCA/src/SecretKey.crysl
@@ -5,14 +5,16 @@ OBJECTS
 	byte[] keyMaterial;
 	
 EVENTS
-	ge: keyMaterial = getEncoded();
-	d: destroy();
+	GetEnc: keyMaterial = getEncoded();
+	
+	Destroy: destroy();
 	
 ORDER
-	ge*, d?
+	GetEnc*, Destroy?
 	
 ENSURES
-	preparedKeyMaterial[keyMaterial] after ge;
+	preparedKeyMaterial[keyMaterial] after GetEnc;
 	
 NEGATES
-	generatedKey[this, _] after d;
+	generatedKey[this, _] after Destroy;
+	

--- a/BouncyCastle-JCA/src/SecretKeyFactory.crysl
+++ b/BouncyCastle-JCA/src/SecretKeyFactory.crysl
@@ -1,4 +1,5 @@
 SPEC javax.crypto.SecretKeyFactory
+
 OBJECTS
     java.lang.String keyFactoryAlgorithm;
     javax.crypto.SecretKey key;
@@ -29,5 +30,6 @@ CONSTRAINTS
 
 REQUIRES
 	speccedKey[keySpec, _];
+	
 ENSURES
     generatedKey[key, keyFactoryAlgorithm];

--- a/BouncyCastle-JCA/src/SecretKeyFactory.crysl
+++ b/BouncyCastle-JCA/src/SecretKeyFactory.crysl
@@ -14,7 +14,6 @@ EVENTS
 
     gS: key = generateSecret(keySpec);
     tK: key = translateKey(otherKey);
-    
     Gens := gS | tK;
 
 ORDER
@@ -33,3 +32,4 @@ REQUIRES
 	
 ENSURES
     generatedKey[key, keyFactoryAlgorithm];
+    

--- a/BouncyCastle-JCA/src/SecretKeyFactory.crysl
+++ b/BouncyCastle-JCA/src/SecretKeyFactory.crysl
@@ -1,23 +1,23 @@
 SPEC javax.crypto.SecretKeyFactory
 
 OBJECTS
-    java.lang.String keyFactoryAlgorithm;
-    javax.crypto.SecretKey key;
-    javax.crypto.SecretKey otherKey;
-    java.security.spec.KeySpec keySpec;
-    int keylength;
+	java.lang.String keyFactoryAlgorithm;
+	javax.crypto.SecretKey key;
+	javax.crypto.SecretKey otherKey;
+	java.security.spec.KeySpec keySpec;
+	int keylength;
    
 EVENTS
-    g1: getInstance(keyFactoryAlgorithm);
-    g2: getInstance(keyFactoryAlgorithm, _);
-    Gets := g1 | g2;
+	g1: getInstance(keyFactoryAlgorithm);
+	g2: getInstance(keyFactoryAlgorithm, _);
+	Gets := g1 | g2;
 
-    gS: key = generateSecret(keySpec);
-    tK: key = translateKey(otherKey);
-    Gens := gS | tK;
+	gS: key = generateSecret(keySpec);
+	tK: key = translateKey(otherKey);
+	Gens := gS | tK;
 
 ORDER
-    Gets, Gens
+	Gets, Gens
 
 CONSTRAINTS
 	keyFactoryAlgorithm in {"AES", "PBKDF2", "PBKDF2WithHmacSHA256", "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512",
@@ -31,5 +31,5 @@ REQUIRES
 	speccedKey[keySpec, _];
 	
 ENSURES
-    generatedKey[key, keyFactoryAlgorithm];
+	generatedKey[key, keyFactoryAlgorithm];
     

--- a/BouncyCastle-JCA/src/SecretKeySpec.crysl
+++ b/BouncyCastle-JCA/src/SecretKeySpec.crysl
@@ -12,7 +12,7 @@ EVENTS
 	Cons := c1 | c2;
 	
 ORDER
- 	Cons
+	Cons
  	
 CONSTRAINTS
 	keyAlgorithm in {"AES", "HmacSHA224", "HmacSHA256", "HmacSHA384", "HmacSHA512"};

--- a/BouncyCastle-JCA/src/SecretKeySpec.crysl
+++ b/BouncyCastle-JCA/src/SecretKeySpec.crysl
@@ -9,7 +9,6 @@ OBJECTS
 EVENTS
 	c1: SecretKeySpec(keyMaterial, keyAlgorithm);
 	c2: SecretKeySpec(keyMaterial, off, len, keyAlgorithm);
-		
 	Cons := c1 | c2;
 	
 ORDER
@@ -26,3 +25,4 @@ REQUIRES
 ENSURES
 	speccedKey[this, _];
 	generatedKey[this, keyAlgorithm];
+	

--- a/BouncyCastle-JCA/src/SecretKeySpec.crysl
+++ b/BouncyCastle-JCA/src/SecretKeySpec.crysl
@@ -1,4 +1,5 @@
 SPEC javax.crypto.spec.SecretKeySpec
+
 OBJECTS 
 	java.lang.String keyAlgorithm;
 	byte[] keyMaterial;
@@ -10,11 +11,14 @@ EVENTS
 	c2: SecretKeySpec(keyMaterial, off, len, keyAlgorithm);
 		
 	Cons := c1 | c2;
+	
 ORDER
  	Cons
+ 	
 CONSTRAINTS
 	keyAlgorithm in {"AES", "HmacSHA224", "HmacSHA256", "HmacSHA384", "HmacSHA512"};
 	length[keyMaterial] >= off + len;
+	neverTypeOf[keyMaterial, java.lang.String];
 	
 REQUIRES
 	preparedKeyMaterial[keyMaterial];	

--- a/BouncyCastle-JCA/src/SecureRandom.crysl
+++ b/BouncyCastle-JCA/src/SecureRandom.crysl
@@ -1,12 +1,13 @@
 SPEC java.security.SecureRandom
+
 OBJECTS 
 	byte[] seed;
 	byte[] genSeed;
-	int num;
 	java.lang.String randomAlgorithm;
 	long lSeed;
 	byte[] next;
 	int numB;
+	int randInt;
 
 EVENTS
 	c1: SecureRandom();
@@ -20,7 +21,7 @@ EVENTS
 	
 	Ins := Gets | Cons;
 
-	gS: genSeed = generateSeed(num);	
+	gS: genSeed = generateSeed(_);	
 
 	s1: setSeed(seed);
 	s2: setSeed(lSeed);
@@ -28,21 +29,24 @@ EVENTS
 	
 	ne: next(numB);
 	nB: nextBytes(next);
-	Nexts := ne | nB;
+	nI: randInt = nextInt();
+	Nexts := ne | nB | nI;
 	
 	Ends := gS | Nexts;
 
 ORDER
- 	Ins, Seeds?, Ends*
+ 	Ins, (Seeds?, Ends*)*
  	
 CONSTRAINTS
 	randomAlgorithm in {"DEFAULT", "NONCEANDIV"};
 	
 REQUIRES	
 	randomized[seed];
+	randomized[lSeed];
 	
 ENSURES
 	randomized[this] after Ins;
-	randomized[genSeed];
-	randomized[next];
-	randomized[numB];
+	randomized[genSeed] after gS;
+	randomized[next] after nB;
+	randomized[numB] after ne;
+	randomized[randInt] after nI;

--- a/BouncyCastle-JCA/src/SecureRandom.crysl
+++ b/BouncyCastle-JCA/src/SecureRandom.crysl
@@ -35,7 +35,7 @@ EVENTS
 	Ends := gS | Nexts;
 
 ORDER
- 	Ins, (Seeds?, Ends*)*
+	Ins, (Seeds?, Ends*)*
  	
 CONSTRAINTS
 	randomAlgorithm in {"DEFAULT", "NONCEANDIV"};

--- a/BouncyCastle-JCA/src/SecureRandom.crysl
+++ b/BouncyCastle-JCA/src/SecureRandom.crysl
@@ -50,3 +50,4 @@ ENSURES
 	randomized[next] after nB;
 	randomized[numB] after ne;
 	randomized[randInt] after nI;
+	

--- a/BouncyCastle-JCA/src/Signature.crysl
+++ b/BouncyCastle-JCA/src/Signature.crysl
@@ -1,4 +1,5 @@
 SPEC java.security.Signature
+
 OBJECTS
     byte[] sign;
     byte inpb;
@@ -11,6 +12,8 @@ OBJECTS
     java.security.cert.Certificate cert;
     java.security.spec.AlgorithmParameterSpec params;
     boolean verified;
+    int offset;
+    int len;
 
 EVENTS
     g1: getInstance(signAlgorithm);

--- a/BouncyCastle-JCA/src/Signature.crysl
+++ b/BouncyCastle-JCA/src/Signature.crysl
@@ -59,3 +59,4 @@ ENSURES
     signed[out, inpba] after Signs;
     signed[out, inpBuf] after Signs;
     verified[verified, sign] after Verifies;
+    

--- a/BouncyCastle-JCA/src/Signature.crysl
+++ b/BouncyCastle-JCA/src/Signature.crysl
@@ -1,62 +1,62 @@
 SPEC java.security.Signature
 
 OBJECTS
-    byte[] sign;
-    byte inpb;
-    byte[] inpba;
-    byte[] out;
-    java.nio.ByteBuffer inpBuf;
-    java.lang.String signAlgorithm;
-    java.security.PrivateKey priv;
-    java.security.PublicKey pub;
-    java.security.cert.Certificate cert;
-    java.security.spec.AlgorithmParameterSpec params;
-    boolean verified;
-    int offset;
-    int len;
+	byte[] sign;
+	byte inpb;
+	byte[] inpba;
+	byte[] out;
+	java.nio.ByteBuffer inpBuf;
+	java.lang.String signAlgorithm;
+	java.security.PrivateKey priv;
+	java.security.PublicKey pub;
+	java.security.cert.Certificate cert;
+	java.security.spec.AlgorithmParameterSpec params;
+	boolean verified;
+	int offset;
+	int len;
 
 EVENTS
-    g1: getInstance(signAlgorithm);
-    g2: getInstance(signAlgorithm, _);
-    Gets := g1 | g2;
+	g1: getInstance(signAlgorithm);
+	g2: getInstance(signAlgorithm, _);
+	Gets := g1 | g2;
 
-    i1: initSign(priv);
-    i2: initSign(priv, _);
-    i3: initVerify(cert);
-    i4: initVerify(pub);
-    InitSigns := i1 | i2;
-    InitVerifies := i3 | i4;
+	i1: initSign(priv);
+	i2: initSign(priv, _);
+	i3: initVerify(cert);
+	i4: initVerify(pub);
+	InitSigns := i1 | i2;
+	InitVerifies := i3 | i4;
 
-    u1: update(inpb);
-    u2: update(inpba);
-    u3: update(inpba, offset, len);
-    u4: update(inpBuf);
-    Updates := u1 | u2 | u3 | u4;
+	u1: update(inpb);
+	u2: update(inpba);
+	u3: update(inpba, offset, len);
+	u4: update(inpBuf);
+	Updates := u1 | u2 | u3 | u4;
 
-    s1: out = sign();
-    s2: sign(out, offset, len);
-    Signs := s1 | s2;
+	s1: out = sign();
+	s2: sign(out, offset, len);
+	Signs := s1 | s2;
 
-    v1: verified = verify(sign);
-    v2: verified = verify(sign, offset, len);
-    Verifies := v1 | v2;
+	v1: verified = verify(sign);
+	v2: verified = verify(sign, offset, len);
+	Verifies := v1 | v2;
 
 ORDER
-    Gets, ((InitSigns+, (Updates+, Signs+)+ )+ | (InitVerifies+, (Updates*, Verifies+)+ )+ )
+	Gets, ((InitSigns+, (Updates+, Signs+)+ )+ | (InitVerifies+, (Updates*, Verifies+)+ )+ )
 
 CONSTRAINTS
-    signAlgorithm in {"ECDDSA", "SHA256WITHECDDSA", "SHA384WITHECDDSA", "SHA512WITHECDDSA", "SHA3-256WITHECDDSA", "SHA3-384WITHECDDSA", 
-    					"SHA3-512WITHECDDSA", "SHA256WITHECNR", "SHA384WITHECNR", "SHA512WITHECNR", "SHA256withECDSA", "SHA256withDSA", 
-    					"SHA224withRSA", "SHA384withRSA", "SHA512withRSA", "SHA256withRSA", "SHA224withDSA", "SHA384withDSA", "SHA512withDSA", 
-    					"QTESLA"};
+	signAlgorithm in {"ECDDSA", "SHA256WITHECDDSA", "SHA384WITHECDDSA", "SHA512WITHECDDSA", "SHA3-256WITHECDDSA", "SHA3-384WITHECDDSA", 
+						"SHA3-512WITHECDDSA", "SHA256WITHECNR", "SHA384WITHECNR", "SHA512WITHECNR", "SHA256withECDSA", "SHA256withDSA", 
+						"SHA224withRSA", "SHA384withRSA", "SHA512withRSA", "SHA256withRSA", "SHA224withDSA", "SHA384withDSA", "SHA512withDSA", 
+						"QTESLA"};
     
 REQUIRES
-    generatedPrivkey[priv];
-    generatedPubkey[pub];
+	generatedPrivkey[priv];
+	generatedPubkey[pub];
 
 ENSURES
-    signed[out, inpb] after Signs;
-    signed[out, inpba] after Signs;
-    signed[out, inpBuf] after Signs;
-    verified[verified, sign] after Verifies;
+	signed[out, inpb] after Signs;
+	signed[out, inpba] after Signs;
+	signed[out, inpBuf] after Signs;
+	verified[verified, sign] after Verifies;
     

--- a/BouncyCastle-JCA/src/TrustAnchor.crysl
+++ b/BouncyCastle-JCA/src/TrustAnchor.crysl
@@ -9,7 +9,6 @@ EVENTS
 	c1: TrustAnchor(_, pubKey, _);
 	c2: TrustAnchor(cert, _);
 	c3: TrustAnchor(princ, pubKey, _);
-	
 	Cons := c1 | c2 | c3;
 	
 ORDER
@@ -20,3 +19,4 @@ REQUIRES
 	
 ENSURES
 	generatedTrustAnchor[this];
+	

--- a/BouncyCastle-JCA/src/TrustAnchor.crysl
+++ b/BouncyCastle-JCA/src/TrustAnchor.crysl
@@ -2,21 +2,18 @@ SPEC java.security.cert.TrustAnchor
 
 OBJECTS
 	java.security.PublicKey pubKey;
-	byte[] nameConstraints;	/* nameConstraints - a byte array containing the ASN.1 DER encoding of a 
-	 						 * NameConstraints extension to be used for checking name constraints. 
-	 						 * Only the value of the extension is included, not the OID or criticality flag. 
-	 						 * Specify null to omit the parameter. */
-	 						 
 	java.security.cert.X509Certificate cert;
 	javax.security.auth.x500.X500Principal princ;
 	
 EVENTS
-	c1: TrustAnchor(_,pubKey,nameConstraints);
-	c2: TrustAnchor(cert, nameConstraints);
-	c3: TrustAnchor(princ, pubKey, nameConstraints);
+	c1: TrustAnchor(_, pubKey, _);
+	c2: TrustAnchor(cert, _);
+	c3: TrustAnchor(princ, pubKey, _);
+	
+	Cons := c1 | c2 | c3;
 	
 ORDER
-	c1 | c2 | c3
+	Cons
 	
 REQUIRES
 	generatedPubkey[pubKey];

--- a/BouncyCastle-JCA/src/TrustManagerFactory.crysl
+++ b/BouncyCastle-JCA/src/TrustManagerFactory.crysl
@@ -29,4 +29,4 @@ REQUIRES
 															
 ENSURES
 	generatedTrustManager[this] after Init;			
-	generatedTrustManagers[tms];															
+	generatedTrustManagers[tms] after gtm;															

--- a/BouncyCastle-JCA/src/TrustManagerFactory.crysl
+++ b/BouncyCastle-JCA/src/TrustManagerFactory.crysl
@@ -15,10 +15,10 @@ EVENTS
 	i2: init(params);
 	Init := i1 | i2;
 	
-	gtm: tms = getTrustManagers();
+	GetTrustMng: tms = getTrustManagers();
 	
 ORDER
-	Gets, Init, gtm?
+	Gets, Init, GetTrustMng?
 	
 CONSTRAINTS
 	algo in {"PKIX", "X509", "X.509"};
@@ -29,4 +29,5 @@ REQUIRES
 															
 ENSURES
 	generatedTrustManager[this] after Init;			
-	generatedTrustManagers[tms] after gtm;															
+	generatedTrustManagers[tms] after GetTrustMng;	
+															


### PR DESCRIPTION
JavaCryptographicArchitecture and BouncyCastle-JCA rulesets should mostly have the same structure and rules since the latter ruleset describes an implementation of the JCA's APIs by the BouncyCastle third-party provider. The only difference between the two rulesets is the CONSTRAINTS section, where they might be providing the implementation of the JCA's APIs through different cryptographic algorithms.

The pull requests [1](https://github.com/CROSSINGTUD/Crypto-API-Rules/pull/68) and [2](https://github.com/CROSSINGTUD/Crypto-API-Rules/pull/67) introduce many changes in the JavaCryptographicArchitecture ruleset. These changes were not included in the BouncyCastle-JCA ruleset.

In order to keep consistency between the two rulesets, this PR updates and refactors all the BouncyCastle-JCA ruleset. Mainly, the ORDER, REQUIRES, and ENSURES section of the rules are updated. The version of BouncyCastle-JCA ruleset is also increased from 0.3 to 0.4 since this PR contains a lot of changes.