### PR TITLE
Fix SecretKeyFactory rule in JCA and BC-JCA ruleset

### DIFF
--- a/BouncyCastle-JCA/src/SecretKeyFactory.crysl
+++ b/BouncyCastle-JCA/src/SecretKeyFactory.crysl
@@ -5,7 +5,6 @@ OBJECTS
 	javax.crypto.SecretKey key;
 	javax.crypto.SecretKey otherKey;
 	java.security.spec.KeySpec keySpec;
-	int keylength;
    
 EVENTS
 	g1: getInstance(keyFactoryAlgorithm);
@@ -25,7 +24,7 @@ CONSTRAINTS
 				"PBEWithSHA256And192BitAES-CBC-BC", "PBEWithSHA256And256BitAES-CBC-BC", "Camellia", 
 				"PBEwithSHAandTwofish-CBC"};					
 	keyFactoryAlgorithm in {"AES", "PBKDF2", "PBKDF2WithHmacSHA256", "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512",
-				"PBKDF2WITHHMACSHA3-256", "PBKDF2WITHHMACSHA3-384", "PBKDF2WITHHMACSHA3-512"} => keylength in {128, 192, 256};
+				"PBKDF2WITHHMACSHA3-256", "PBKDF2WITHHMACSHA3-384", "PBKDF2WITHHMACSHA3-512"};
 
 REQUIRES
 	speccedKey[keySpec, _];

--- a/JavaCryptographicArchitecture/src/SecretKeyFactory.crysl
+++ b/JavaCryptographicArchitecture/src/SecretKeyFactory.crysl
@@ -5,7 +5,6 @@ OBJECTS
 	javax.crypto.SecretKey key;
 	javax.crypto.SecretKey otherKey;
 	java.security.spec.KeySpec keySpec;
-	int keylength;
    
 EVENTS
 	g1: getInstance(keyFactoryAlgorithm);
@@ -24,11 +23,11 @@ CONSTRAINTS
 				"PBEWithHmacSHA512AndAES_128","PBEWithHmacSHA384AndAES_128", "PBEWithHmacSHA384AndAES_128", 
 				"PBEWithHmacSHA224AndAES_128", "PBEWithHmacSHA256AndAES_128","PBEWithHmacSHA224AndAES_256", 
 				"PBEWithHmacSHA256AndAES_256", "PBEWithHmacSHA384AndAES_256", "PBEWithHmacSHA512AndAES_256"};
-	keyFactoryAlgorithm in {"PBEWithHmacSHA224AndAES_128", "PBEWithHmacSHA256AndAES_128", "PBEWithHmacSHA512AndAES_128"} => keylength in {128};
+	keyFactoryAlgorithm in {"PBEWithHmacSHA224AndAES_128", "PBEWithHmacSHA256AndAES_128", "PBEWithHmacSHA512AndAES_128"};
 	keyFactoryAlgorithm in {"PBEWithHmacSHA224AndAES_256", "PBEWithHmacSHA256AndAES_256", "PBEWithHmacSHA384AndAES_256", 
-				"PBEWithHmacSHA512AndAES_256"} => keylength in {256};
+				"PBEWithHmacSHA512AndAES_256"};
 	keyFactoryAlgorithm in {"PBKDF2WithHmacSHA224", "PBKDF2WithHmacSHA256", "PBKDF2WithHmacSHA384", 
-				"PBKDF2WithHmacSHA512"} => keylength in {128, 192, 256};
+				"PBKDF2WithHmacSHA512"};
 
 REQUIRES
 	speccedKey[keySpec, _];


### PR DESCRIPTION
Fixes #50 

This PR fixes a typo in the SecretKeyFactory rule where the `keylength` object is redundant and never used. This is based on the official documentation [here](https://docs.oracle.com/javase/7/docs/api/javax/crypto/SecretKeyFactory.html).