### PR TITLE
Removed some events because they are protected

### DIFF
--- a/BouncyCastle-JCA/src/SecureRandom.crysl
+++ b/BouncyCastle-JCA/src/SecureRandom.crysl
@@ -46,6 +46,5 @@ ENSURES
 	randomized[this] after Ins;
 	randomized[genSeed] after gS;
 	randomized[next] after nB;
-	randomized[numB] after ne;
 	randomized[randInt] after nI;
 	

--- a/BouncyCastle-JCA/src/SecureRandom.crysl
+++ b/BouncyCastle-JCA/src/SecureRandom.crysl
@@ -6,7 +6,6 @@ OBJECTS
 	java.lang.String randomAlgorithm;
 	long lSeed;
 	byte[] next;
-	int numB;
 	int randInt;
 
 EVENTS

--- a/BouncyCastle-JCA/src/SecureRandom.crysl
+++ b/BouncyCastle-JCA/src/SecureRandom.crysl
@@ -27,10 +27,9 @@ EVENTS
 	s2: setSeed(lSeed);
 	Seeds := s1 | s2;
 	
-	ne: next(numB);
 	nB: nextBytes(next);
 	nI: randInt = nextInt();
-	Nexts := ne | nB | nI;
+	Nexts := nB | nI;
 	
 	Ends := gS | Nexts;
 

--- a/JavaCryptographicArchitecture/src/CipherInputStream.crysl
+++ b/JavaCryptographicArchitecture/src/CipherInputStream.crysl
@@ -8,9 +8,8 @@ OBJECTS
 	int len;
 	
 EVENTS
-	c1: CipherInputStream(is);
-	c2: CipherInputStream(is, ciph);
-	Cons := c1 | c2;
+	c1: CipherInputStream(is, ciph);
+	Cons := c1:
 	
 	r1: read();
 	r2: read(buffer); 

--- a/JavaCryptographicArchitecture/src/CipherOutputStream.crysl
+++ b/JavaCryptographicArchitecture/src/CipherOutputStream.crysl
@@ -9,9 +9,8 @@ OBJECTS
 	int specifiedByte;
 	
 EVENTS
-	c1: CipherOutputStream(os);
-	c2: CipherOutputStream(os, ciph);
-	Cons := c1 | c2;
+	c1: CipherOutputStream(os, ciph);
+	Cons := c1;
 	
 	w1: write(specifiedByte);
 	w2: write(data);

--- a/JavaCryptographicArchitecture/src/SecureRandom.crysl
+++ b/JavaCryptographicArchitecture/src/SecureRandom.crysl
@@ -6,7 +6,6 @@ OBJECTS
 	java.lang.String randomAlgorithm;
 	long lSeed;
 	byte[] next;
-	int numB;
 	int randInt;
 	
 EVENTS
@@ -27,7 +26,6 @@ EVENTS
 
 	gS: genSeed = generateSeed(_);	
 
-	ne: next(numB);
 	nB: nextBytes(next);
 	nI: randInt = nextInt();
 	Nexts := ne | nB | nI;
@@ -48,6 +46,5 @@ ENSURES
 	randomized[this] after Ins;
 	randomized[genSeed] after gS;
 	randomized[next] after nB;
-	randomized[numB] after ne;
 	randomized[randInt] after nI;
 	

--- a/JavaCryptographicArchitecture/src/SecureRandom.crysl
+++ b/JavaCryptographicArchitecture/src/SecureRandom.crysl
@@ -28,7 +28,7 @@ EVENTS
 
 	nB: nextBytes(next);
 	nI: randInt = nextInt();
-	Nexts := ne | nB | nI;
+	Nexts := nB | nI;
 	
 	Ends := gS | Nexts;
 


### PR DESCRIPTION
Some CrySL rules also specify protected methods in their EVENTS section. In reality, the users of cryptographic classes use only the public methods and hence such specifications are redundant.

`next(int)` cannot be invoked on SecureRandom object since it's protected
https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html#next-int-

The constructor `CipherInputStream(InputStream is)` of CipherInputStream class is protected
https://docs.oracle.com/javase/7/docs/api/javax/crypto/CipherInputStream.html

The constructor `CipherOutputStream(OutputStream os)` of CipherOutputStream class is protected
https://docs.oracle.com/javase/7/docs/api/javax/crypto/CipherInputStream.html
