### PR TITLE
adding crysl rule specifications for AESFastEngine, AESLightEngine an…

### DIFF
--- a/BouncyCastle/src/AESEngine.crysl
+++ b/BouncyCastle/src/AESEngine.crysl
@@ -1,14 +1,14 @@
 SPEC org.bouncycastle.crypto.engines.AESEngine
 
 OBJECTS
-	int dummy;
+	int dummy; //This section can't be empty or else the rule is marked with an error.
 
 EVENTS
-	c : AESEngine();
+	Con : AESEngine();
 	
 ORDER
-	c
+	Con
 	
 ENSURES
 	generatedAESEngine[this];
-	
+

--- a/BouncyCastle/src/AESFastEngine.crysl
+++ b/BouncyCastle/src/AESFastEngine.crysl
@@ -1,15 +1,16 @@
+//The AESFastEngine class is deprecated and insecure. This crysl rule ensures that a AESFastEngine object is considered insecure.
 SPEC org.bouncycastle.crypto.engines.AESFastEngine
 
 OBJECTS
 	int dummy; //This section can't be empty or else the rule is marked with an error.
+	
+FORBIDDEN
+	AESFastEngine() ;
 
 EVENTS	
 	Con : AESFastEngine();
 	
 ORDER
 	Con
-
-ENSURES
-	generatedAESFastEngine[this];
 
 

--- a/BouncyCastle/src/AESFastEngine.crysl
+++ b/BouncyCastle/src/AESFastEngine.crysl
@@ -1,0 +1,13 @@
+SPEC org.bouncycastle.crypto.engines.AESFastEngine
+
+OBJECTS
+	int dummy;
+
+EVENTS	
+	c : AESFastEngine();
+	
+ORDER
+	c
+
+ENSURES
+	generatedAESFastEngine[this];

--- a/BouncyCastle/src/AESFastEngine.crysl
+++ b/BouncyCastle/src/AESFastEngine.crysl
@@ -1,13 +1,15 @@
 SPEC org.bouncycastle.crypto.engines.AESFastEngine
 
 OBJECTS
-	int dummy;
+	int dummy; //This section can't be empty or else the rule is marked with an error.
 
 EVENTS	
-	c : AESFastEngine();
+	Con : AESFastEngine();
 	
 ORDER
-	c
+	Con
 
 ENSURES
 	generatedAESFastEngine[this];
+
+

--- a/BouncyCastle/src/AESLightEngine.crysl
+++ b/BouncyCastle/src/AESLightEngine.crysl
@@ -1,13 +1,15 @@
 SPEC org.bouncycastle.crypto.engines.AESLightEngine
 
 OBJECTS
-	int dummy;
+	int dummy; //This section can't be empty or else the rule is marked with an error.
 
 EVENTS	
-	c : AESLightEngine();
+	Con : AESLightEngine();
 	
 ORDER
-	c
+	Con
 
 ENSURES
 	generatedAESLightEngine[this];
+
+

--- a/BouncyCastle/src/AESLightEngine.crysl
+++ b/BouncyCastle/src/AESLightEngine.crysl
@@ -1,0 +1,13 @@
+SPEC org.bouncycastle.crypto.engines.AESLightEngine
+
+OBJECTS
+	int dummy;
+
+EVENTS	
+	c : AESLightEngine();
+	
+ORDER
+	c
+
+ENSURES
+	generatedAESLightEngine[this];

--- a/BouncyCastle/src/CBCBlockCipher.crysl
+++ b/BouncyCastle/src/CBCBlockCipher.crysl
@@ -8,11 +8,15 @@ EVENTS
 
 //No need to specify the order, must be wrapped in PaddedBufferedCipher!
 	
+
 ORDER
 	Con
-
+	
+CONSTRAINTS
+	neverTypeOf[engine, org.bouncycastle.crypto.engines.AESFastEngine];
+	
 REQUIRES
-	generatedAESEngine[engine] || generatedAESFastEngine[engine] || generatedAESLightEngine[engine];
+	generatedAESEngine[engine] || generatedAESLightEngine[engine];
 	
 ENSURES
 	generatedCBCBlockCipher[this];

--- a/BouncyCastle/src/CBCBlockCipher.crysl
+++ b/BouncyCastle/src/CBCBlockCipher.crysl
@@ -4,15 +4,16 @@ OBJECTS
 	org.bouncycastle.crypto.BlockCipher engine;
 	
 EVENTS
-	c : CBCBlockCipher(engine);
+	Con : CBCBlockCipher(engine);
 
 //No need to specify the order, must be wrapped in PaddedBufferedCipher!
 	
 ORDER
-	c
+	Con
 
 REQUIRES
-	generatedAESEngine[engine];
+	generatedAESEngine[engine] || generatedAESFastEngine[engine] || generatedAESLightEngine[engine];
 	
 ENSURES
 	generatedCBCBlockCipher[this];
+	

--- a/BouncyCastle/src/GCMBlockCipher.crysl
+++ b/BouncyCastle/src/GCMBlockCipher.crysl
@@ -19,9 +19,12 @@ EVENTS
 	
 ORDER
 	Con, Init, Process+, doFinal
+	
+CONSTRAINTS
+	neverTypeOf[engine, org.bouncycastle.crypto.engines.AESFastEngine];
 
 REQUIRES
-	generatedAESEngine[engine] || generatedAESFastEngine[engine] || generatedAESLightEngine[engine];
+	generatedAESEngine[engine] || generatedAESLightEngine[engine];
 	generatedAEADParameters[params] || generatedParametersWithIV[params];
 		
 	

--- a/BouncyCastle/src/GCMBlockCipher.crysl
+++ b/BouncyCastle/src/GCMBlockCipher.crysl
@@ -5,23 +5,25 @@ OBJECTS
 	org.bouncycastle.crypto.CipherParameters params;
 	
 EVENTS
-	Cons : GCMBlockCipher(engine);
-	init: init(_,params);
+	Con : GCMBlockCipher(engine);
+	
+	Init: init(_,params);
+	
 	p1: processAADByte(_);
 	p2: processAADBytes(_,_,_);
 	p3: processByte(_,_,_);
 	p4: processBytes(_,_,_,_,_);
+	Process := p1 | p2 | p3 | p4;
 	
-	process := p1 | p2 | p3 | p4;
 	doFinal: doFinal(_,_);
 	
 ORDER
-	Cons, init, process+, doFinal
+	Con, Init, Process+, doFinal
 
 REQUIRES
-	generatedAESEngine[engine];
+	generatedAESEngine[engine] || generatedAESFastEngine[engine] || generatedAESLightEngine[engine];
 	generatedAEADParameters[params] || generatedParametersWithIV[params];
 		
 	
 ENSURES
-	generatedGCMBlockCipherMode[this] after Cons;
+	generatedGCMBlockCipherMode[this] after Con;

--- a/BouncyCastle/src/RijndaelEngine.crysl
+++ b/BouncyCastle/src/RijndaelEngine.crysl
@@ -1,0 +1,18 @@
+SPEC org.bouncycastle.crypto.engines.RijndaelEngine
+
+OBJECTS
+	int blockSize;
+
+EVENTS
+	c1 : RijndaelEngine();
+	c2 : RijndaelEngine(blockSize);
+	c := c1 | c2;
+
+ORDER
+	c
+
+CONSTRAINTS
+	blockSize in {128,192,256};
+
+ENSURES
+	generatedRijndaelEngine[this];

--- a/BouncyCastle/src/RijndaelEngine.crysl
+++ b/BouncyCastle/src/RijndaelEngine.crysl
@@ -6,13 +6,14 @@ OBJECTS
 EVENTS
 	c1 : RijndaelEngine();
 	c2 : RijndaelEngine(blockSize);
-	c := c1 | c2;
+	Cons := c1 | c2;
 
 ORDER
-	c
+	Cons
 
 CONSTRAINTS
 	blockSize in {128,192,256};
 
 ENSURES
 	generatedRijndaelEngine[this];
+


### PR DESCRIPTION
implements #84 
This pull requests implements the crysl rules for the AESFastEngine, AESLightEngine and RijndaelEngine. 
Furthermore AES-192 and AES-256 are about the key length being 192,256 bits and not the blocksize. This is already supported by the current implementation of crysl rules.