### PR TITLE
Fix typo in CipherInputStream rule

### DIFF
--- a/JavaCryptographicArchitecture/src/CipherInputStream.crysl
+++ b/JavaCryptographicArchitecture/src/CipherInputStream.crysl
@@ -9,7 +9,7 @@ OBJECTS
 	
 EVENTS
 	c1: CipherInputStream(is, ciph);
-	Cons := c1:
+	Cons := c1;
 	
 	r1: read();
 	r2: read(buffer); 


### PR DESCRIPTION
There is a colon in the CipherInputStream rule, instead of a semicolon.