### PR TITLE
Implement CCMBlockCIpher and SICBlockCipher clean

### DIFF
--- a/BouncyCastle/src/BufferedBlockCipher.crysl
+++ b/BouncyCastle/src/BufferedBlockCipher.crysl
@@ -8,27 +8,26 @@ OBJECTS
 	byte[] cipherText;
 	
 EVENTS
-	c1 : BufferedBlockCipher(engineOrMode);
-	Cons := c1;
+	c1: BufferedBlockCipher(engineOrMode);
+	Con := c1;
 
 	i : init(is_encryption, params);
-	Inits := i;
+	Init := i;
 
 //	@return the number of output bytes copied to out.
 	p1: processByte(_ ,_ ,_ );
 	p2: processBytes(_ ,_ ,_ ,_ ,_ );
-	Procs := p1 | p2;
+	Process := p1 | p2;
 	
 //	@return the number of output bytes copied to out.
 	f : doFinal(cipherText, _);
-	DOFINALS := f;
+	doFinal := f;
 	
 ORDER
-	Cons, (Inits, Procs, DOFINALS)+
-
+	Con, (Init, Process, doFinal)+
 	
 REQUIRES
-	generatedGCMBlockCipher[engineOrMode];
+	generatedSICBlockCipher[engineOrMode];
 	generatedCipherParams[params];
 	
 ENSURES

--- a/BouncyCastle/src/CCMBlockCipher.crysl
+++ b/BouncyCastle/src/CCMBlockCipher.crysl
@@ -1,0 +1,26 @@
+SPEC org.bouncycastle.crypto.modes.CCMBlockCipher
+
+OBJECTS
+	org.bouncycastle.crypto.BlockCipher engine;
+	org.bouncycastle.crypto.CipherParameters params;
+
+EVENTS
+	Con: CCMBlockCipher(engine);
+
+	Init: init(_,params);
+
+	p1: processAADByte(_);
+	p2: processAADBytes(_,_,_);
+	p3: processByte(_,_,_);
+	p4: processBytes(_,_,_,_,_);
+	p5: processPacket(_,_,_);
+	Process := p1 | p2 | p3 | p4 | p5;
+
+	doFinal: doFinal(_,_);
+
+ORDER
+	Con, Init, Process+, doFinal
+
+REQUIRES
+	generatedAESEngine[engine] || generatedAESLightEngine[engine] || generatedRijndaelEngine[engine];
+	generatedAEADParameters[params] || generatedParametersWithIV[params];

--- a/BouncyCastle/src/SICBlockCipher.crysl
+++ b/BouncyCastle/src/SICBlockCipher.crysl
@@ -1,0 +1,19 @@
+SPEC org.bouncycastle.crypto.modes.SICBlockCipher
+
+OBJECTS
+
+	org.bouncycastle.crypto.BlockCipher engine;
+	
+EVENTS
+	Con: SICBlockCipher(engine);
+	
+//No need to specify the order, must be wrapped in BufferedCipher
+	
+ORDER
+	Con
+
+REQUIRES
+	generatedAESEngine[engine] || generatedAESLightEngine[engine] || generatedRijndaelEngine[engine];
+
+ENSURES
+	generatedSICBlockCipher[this];


### PR DESCRIPTION
closes #85 
This pull request implements the crysl rules for the recommended modes of operation for block ciphers (CCM and CTR). Furthermore, the SICBlockCipher is added to the REQUIRES section of the BufferedBlockCipher crysl rule.

This pull request is a cleaned-up version of #89 as the old pull request had some commit history issues.