### PR TITLE
WIP: Refactor bc jca ruleset

### DIFF
--- a/BouncyCastle-JCA/src/AlgorithmParameterGenerator.crysl
+++ b/BouncyCastle-JCA/src/AlgorithmParameterGenerator.crysl
@@ -10,22 +10,24 @@ OBJECTS
 EVENTS
 	g1: getInstance(algorithm);
 	g2: getInstance(algorithm, _);
-	Gets := g1 | g2;
+	Get := g1 | g2;
 
 	i1: init(size);
 	i2: init(size, random);
 	i3: init(genParamSpec);
 	i4: init(genParamSpec, random);
-	Inits := i1 | i2 | i3 | i4;
+	Init := i1 | i2 | i3 | i4;
     
-	GenParam: algParams = generateParameters();
+	gp1: algParams = generateParameters();
+	GenParam := gp1;
     
 ORDER
-	Gets, Inits, GenParam
+	Get, Init, GenParam
 	
 CONSTRAINTS
 	algorithm in {"AES", "Camellia", "Shacal2", "Shacal-2", "DH", "DiffieHellman", "DSA", "ElGamal"};
-	size in {1024};
+	algorithm in {"DH", "DSA", "ElGamal"} => size in {1048};
+	algorithm in {"AES", "Camellia", "Shacal2", "Shacal-2" } => size in {128, 192, 256};
 
 REQUIRES
 	randomized[random];

--- a/BouncyCastle-JCA/src/AlgorithmParameters.crysl
+++ b/BouncyCastle-JCA/src/AlgorithmParameters.crysl
@@ -1,46 +1,50 @@
 SPEC java.security.AlgorithmParameters
 
 OBJECTS
-	java.lang.String alg;
-	java.security.spec.AlgorithmParameterSpec params;
-	byte[] parAr; 
+	java.lang.String algorithm;
+	java.security.spec.AlgorithmParameterSpec paramSpec;
+	byte[] params; 
 	java.lang.String format;
-	byte[] parsRes;
+	byte[] encParams;
 
 EVENTS
-	g1: getInstance(alg);
-	g2: getInstance(alg, _);
-	Gets := g1 | g2;
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
+	Get := g1 | g2;
 
-	i1: init(params);
-	i2: init(parAr);
-	i3: init(parAr, _);
-	Inits := i1 | i2 | i3;
+	i1: init(paramSpec);
+	i2: init(params);
+	i3: init(params, _);
+	Init := i1 | i2 | i3;
     
-	e1: parsRes = getEncoded();
-	e2: parsRes = getEncoded(format);
-	GetEncs := e1 | e2;
+	e1: encParams = getEncoded();
+	e2: encParams = getEncoded(format);
+	GetEncoded := e1 | e2;
 
 ORDER
-	Gets, Inits, GetEncs?
+	Get, Init, GetEncoded?
 
 CONSTRAINTS
-	alg in {"AES", "Camellia", "ChaCha7539", "DSA", "DiffieHellman", "DH", "EC", "ElGamal", "PBKDF2", "Rijndael", "Salsa20", "Tnepres", 
+	algorithm in {"AES", "Camellia", "ChaCha7539", "DSA", "DiffieHellman", "DH", "EC", "ElGamal", "PBKDF2", "Rijndael", "Salsa20", "Tnepres", 
 		"Serpent", "SHACAL-2", "Shacal2", "Twofish", "XSalsa20", "OAEP", "PSS", "RSAPSS", "SHA256withRSA/PSS", "SHA384withRSA/PSS", 
 		"SHA512withRSA/PSS", "SHA256WITHRSAANDMGF1", "SHA386WITHRSAANDMGF1", "SHA512WITHRSAANDMGF1", "SHA3-256WITHRSAANDMGF1", 
 		"SHA3-386WITHRSAANDMGF1", "SHA3-512WITHRSAANDMGF1"};
 
 REQUIRES    
-	preparedAlg[parAr, alg];
-	alg in {"AES", "Camellia", "ChaCha7539", "ElGamal", "PBKDF2", "Rijndael", "Salsa20", "Tnepres", "Serpent", "SHACAL-2",
+	preparedAlg[params, algorithm];
+	algorithm in {"AES", "Camellia", "ChaCha7539", "ElGamal", "PBKDF2", "Rijndael", "Salsa20", "Tnepres", "Serpent", "SHACAL-2",
 		"Shacal2", "Twofish", "XSalsa20", "OAEP", "PSS", "RSAPSS", "SHA256withRSA/PSS", "SHA384withRSA/PSS", "SHA512withRSA/PSS",
 		"SHA256WITHRSAANDMGF1", "SHA386WITHRSAANDMGF1", "SHA512WITHRSAANDMGF1", "SHA3-256WITHRSAANDMGF1", "SHA3-386WITHRSAANDMGF1",
-		"SHA3-512WITHRSAANDMGF1"} => preparedIV[params];
-	alg in {"DiffieHellman", "DH"} => preparedDH[params];
-	alg in {"DSA"} => preparedDSA[params];
-	alg in {"EC"} => preparedEC[params];
+		"SHA3-512WITHRSAANDMGF1"} => preparedIV[paramSpec];
+	algorithm in {"DiffieHellman", "DH"} => preparedDH[paramSpec];
+	algorithm in {"DSA"} => preparedDSA[paramSpec];
+	algorithm in {"EC"} => preparedEC[paramSpec];
+	algorithm in {"OAEP"} => preparedOAEP[paramSpec];
+	algorithm in {"PBEWithHmacSHA224AndAES_128", "PBEWithHmacSHA256AndAES_128", "PBEWithHmacSHA384AndAES_128", 
+		"PBEWithHmacSHA512AndAES_128", "PBEWithHmacSHA224AndAES_256", "PBEWithHmacSHA256AndAES_256", 
+		"PBEWithHmacSHA384AndAES_256", "PBEWithHmacSHA512AndAES_256"} => preparedPBE[paramSpec];
     
 ENSURES 
-	preparedAlg[this, alg] after Inits;
-	preparedAlg[parsRes, alg] after GetEncs;
+	preparedAlg[this, algorithm] after Init;
+	preparedAlg[encParams, algorithm] after GetEncoded;
     

--- a/BouncyCastle-JCA/src/CertPathTrustManagerParameters.crysl
+++ b/BouncyCastle-JCA/src/CertPathTrustManagerParameters.crysl
@@ -4,7 +4,8 @@ OBJECTS
 	java.security.cert.CertPathParameters params;
 
 EVENTS
-	Con: CertPathTrustManagerParameters(params);	
+	c1: CertPathTrustManagerParameters(params);
+	Con := c1;
 	
 ORDER
 	Con
@@ -14,4 +15,3 @@ REQUIRES
 	
 ENSURES
 	generatedManagerFactoryParameters[this];
-	

--- a/BouncyCastle-JCA/src/CertificateFactory.crysl
+++ b/BouncyCastle-JCA/src/CertificateFactory.crysl
@@ -3,27 +3,29 @@ SPEC java.security.cert.CertificateFactory
 OBJECTS
 	java.io.InputStream inStream;
 	java.lang.String encoding;
-	java.lang.String alg;
+	java.lang.String type;
 
 EVENTS
-	g1: getInstance(alg);
-	g2: getInstance(alg, _);
-	Gets := g1 | g2;
+	g1: getInstance(type);
+	g2: getInstance(type, _);
+	Get := g1 | g2;
 	
-	GenCert: generateCertificate(inStream);
+	gc1: generateCertificate(inStream);
+	GenCert := gc1;
 	
 	gen1: generateCertPath(inStream);
 	gen2: generateCertPath(inStream, encoding);
-	GenCertPaths := gen1 | gen2;
+	GenCertPath := gen1 | gen2;
 	
-	GenCRL: generateCRL(inStream);
+	gcrl1: generateCRL(inStream);
+	GenCRL := gcrl1;
 	
 ORDER
-	Gets, (GenCert | GenCertPaths | GenCRL)+
+	Get, (GenCert | GenCertPath | GenCRL)+
 	
 CONSTRAINTS
-	alg in {"X509", "X.509"};
+	type in {"X509", "X.509"};
 	encoding in {"PKCS7", "PkiPath"};
 	
 ENSURES
-	generatedCert[alg];
+	generatedCert[type];

--- a/BouncyCastle-JCA/src/Cipher.crysl
+++ b/BouncyCastle-JCA/src/Cipher.crysl
@@ -4,80 +4,92 @@ OBJECTS
 	java.lang.String transformation;
 	int encmode;
 	java.security.Key key;
-	java.security.cert.Certificate cert;
-	java.security.spec.AlgorithmParameterSpec params;
-	java.security.AlgorithmParameters param;
+	java.security.cert.Certificate certificate;
+	java.security.spec.AlgorithmParameterSpec paramSpec;
+	java.security.AlgorithmParameters params;
     
-	int pre_plain_off;
-	int pre_ciphertext_off;
-	int plain_off;
-	int ciphertext_off;
+	int prePlainTextOffset;
+	int preCipherTextOffset;
+	int plainTextOffset;
+	int cipherTextOffset;
+	int aadOffset;
     
-	int pre_len;
-	int len;
+	int prePlainTextLen;
+	int plainTextLen;
+	int aadLen;
     
-	byte[] pre_plaintext;
-	byte[] pre_ciphertext;
-	java.nio.ByteBuffer pre_plainBuffer;
-	java.nio.ByteBuffer pre_cipherBuffer;
+	byte[] prePlainText;
+	byte[] preCipherText;
+	java.nio.ByteBuffer prePlainTextByteBuffer;
+	java.nio.ByteBuffer preCipherTextByteBuffer;
     
 	byte[] plainText;
 	byte[] cipherText;
 	byte[] wrappedKeyBytes;
-	java.nio.ByteBuffer plainBuffer;
-	java.nio.ByteBuffer cipherBuffer;
+	java.nio.ByteBuffer plainTextByteBuffer;
+	java.nio.ByteBuffer cipherTextByteBuffer;
 	
-	java.security.SecureRandom ranGen;
+	byte[] aadBytes;
+	java.nio.ByteBuffer aadByteBuffer;
+	
+	java.security.SecureRandom random;
 	
 	java.security.Key wrappedKey;
 
 EVENTS
 	g1: getInstance(transformation);
 	g2: getInstance(transformation, _);
-	Gets := g1 | g2;
+	Get := g1 | g2;
 
-	i1: init(encmode, cert);
-	i2: init(encmode, cert, ranGen);
+	i1: init(encmode, certificate);
+	i2: init(encmode, certificate, random);
 	i3: init(encmode, key);
-	i4: init(encmode, key, params);
-	i5: init(encmode, key, param);
-	i6: init(encmode, key, params, ranGen);
-	i7: init(encmode, key, param, ranGen);
-	i8: init(encmode, key, ranGen);
+	i4: init(encmode, key, paramSpec);
+	i5: init(encmode, key, params);
+	i6: init(encmode, key, paramSpec, random);
+	i7: init(encmode, key, params, random);
+	i8: init(encmode, key, random);
 	IWOIV := i1 | i2 | i3 | i8;
 	IWIV :=  i4 | i5 | i6 | i7;
-	Inits := IWOIV | IWIV;
+	Init := IWOIV | IWIV;
 
-	u1: pre_ciphertext = update(pre_plaintext);
-	u2: pre_ciphertext = update(pre_plaintext, pre_plain_off, _);
-	u3: update(pre_plaintext, pre_plain_off, pre_len, pre_ciphertext);
-	u4: update(pre_plaintext, pre_plain_off, pre_len, pre_ciphertext, pre_ciphertext_off);
-	u5: update(pre_plainBuffer, pre_cipherBuffer);
-	Updates := u1 | u2 | u3 | u4 | u5;
-
+	u1: preCipherText = update(prePlainText);
+	u2: preCipherText = update(prePlainText, prePlainTextOffset, _);
+	u3: update(prePlainText, prePlainTextOffset, prePlainTextLen, preCipherText);
+	u4: update(prePlainText, prePlainTextOffset, prePlainTextLen, preCipherText, preCipherTextOffset);
+	u5: update(prePlainTextByteBuffer, preCipherTextByteBuffer);
+	Update := u1 | u2 | u3 | u4 | u5;
+	
+	ua1: updateAAD(aadBytes);
+	ua2: updateAAD(aadBytes, aadOffset, aadLen);
+	ua3: updateAAD(aadByteBuffer);
+	AADUpdate := ua1 | ua2 | ua3;
+	
 	f1: cipherText = doFinal();
 	f2: cipherText =  doFinal(plainText);
-	f3: doFinal(cipherText, ciphertext_off);
-	f4: cipherText = doFinal(plainText, plain_off, len);
-	f5: doFinal(plainText, plain_off, len, cipherText);
-	f6: doFinal(plainText, plain_off, len, cipherText, ciphertext_off);
-	f7: doFinal(plainBuffer, cipherBuffer);
+	f3: doFinal(cipherText, cipherTextOffset);
+	f4: cipherText = doFinal(plainText, plainTextOffset, plainTextLen);
+	f5: doFinal(plainText, plainTextOffset, plainTextLen, cipherText);
+	f6: doFinal(plainText, plainTextOffset, plainTextLen, cipherText, cipherTextOffset);
+	f7: doFinal(plainTextByteBuffer, cipherTextByteBuffer);
 	FINWOU := f2 | f4 | f5 | f6 | f7;
-	DOFINALS := FINWOU | f1 | f3;
+	DoFinal := FINWOU | f1 | f3;
     
-	WKB: wrappedKeyBytes = wrap(wrappedKey);
+	wkb1: wrappedKeyBytes = wrap(wrappedKey);
+	WKB := wkb1;
     
-	IV: getIV();
+	iv1: getIV();
+	IV := iv1;
     
 ORDER
-	Gets, Inits+, WKB+ | (FINWOU | (Updates+, DOFINALS))+
+	Get, Init+, AADUpdate*, WKB+ | (FINWOU | (Update+, DoFinal))+
 
 CONSTRAINTS
 	instanceOf[key, java.security.PublicKey] || instanceOf[key, java.security.PrivateKey] || encmode in {3, 4} => alg(transformation) in {"RSA"};
 	instanceOf[key, javax.crypto.SecretKey] => alg(transformation) in {"AES", "RIJNDAEL", "ElGamal", "ECIESwithAES-CBC", "DHIESwithAES-CBC",
 									"Twofish", "Camellia", "Serpent", "Tnepres", "Shacal2", "Shacal-2", "McEliece", 
 									"McEliecePointcheval", "McElieceKobaraImai", "McElieceFujisaki"};
-	noCallTo[Inits] => alg(transformation) in {"AES", "RSA", "RIJNDAEL", "ElGamal", "ECIESwithAES-CBC", "DHIESwithAES-CBC", "Twofish", "Camellia",
+	noCallTo[Init] => alg(transformation) in {"AES", "RSA", "RIJNDAEL", "ElGamal", "ECIESwithAES-CBC", "DHIESwithAES-CBC", "Twofish", "Camellia",
 						"Serpent", "Tnepres", "Shacal2", "Shacal-2", "McEliece", "McEliecePointcheval", "McElieceKobaraImai",
 						"McElieceFujisaki"};
 																		
@@ -112,16 +124,18 @@ CONSTRAINTS
 	mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB", "CCM"} && encmode != 1 => noCallTo[IWOIV];
 	mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB", "CCM"} && encmode == 1 => callTo[IV];
        	
+    mode(transformation) in {"CBC", "PCBC", "CTR", "CTS", "CFB", "ECB", "OFB"} => noCallTo[AADUpdate];   	
+    
 	encmode in {1,2,3,4};
-	length[pre_plaintext] >= pre_plain_off + len;
-	length[pre_ciphertext] <= pre_ciphertext_off;
-	length[plainText] <= plain_off + len;
-	length[cipherText] <= ciphertext_off;
+	length[prePlainText] >= prePlainTextOffset + prePlainTextLen;
+	length[preCipherText] >= preCipherTextOffset;
+	length[plainText] >= plainTextOffset + plainTextLen;
+	length[cipherText] >= cipherTextOffset;
 
 REQUIRES
 	generatedKey[key, alg(transformation)];
-	randomized[ranGen];
-	preparedAlg[param, alg(transformation)];
+	randomized[random];
+	preparedAlg[params, alg(transformation)];
 	!macced[_, plainText];
 	mode(transformation) in {"CBC", "CTR", "CTS", "CFB", "OFB"} && encmode == 1 => preparedIV[params];
 	mode(transformation) in {"GCM"} => preparedGCM[params];
@@ -129,9 +143,9 @@ REQUIRES
 				"OAEPWithSHA-384AndMGF1Padding", "OAEPWithSHA-512AndMGF1Padding"} => preparedOAEP[params];
 	
 ENSURES
-	generatedCipher[this] after Inits;
-	encrypted[pre_ciphertext, pre_plaintext] after Updates; 
+	generatedCipher[this] after Init;
+	encrypted[preCipherText, prePlainText] after Update; 
 	encrypted[cipherText, plainText];
-	encrypted[cipherBuffer, plainBuffer];
+	encrypted[cipherTextByteBuffer, plainTextByteBuffer];
 	wrappedKey[wrappedKeyBytes, wrappedKey];
 	

--- a/BouncyCastle-JCA/src/CipherInputStream.crysl
+++ b/BouncyCastle-JCA/src/CipherInputStream.crysl
@@ -1,33 +1,33 @@
 SPEC javax.crypto.CipherInputStream
 
 OBJECTS
-	java.io.InputStream is;
-	javax.crypto.Cipher ciph;
-	byte[] b;
-	int off;
+	java.io.InputStream inputStream;
+	javax.crypto.Cipher cipher;
+	byte[] buffer;
+	int offset;
 	int len;
 	
 EVENTS
-	c1: CipherInputStream(is);
-	c2: CipherInputStream(is, ciph);
-	Cons := c1 | c2;
+	c1: CipherInputStream(inputStream, cipher);
+	Con := c1;
 	
 	r1: read();
-	r2: read(b); 
-	r3: read(b, off, len);
-	Reads := r1 | r2 | r3;
+	r2: read(buffer); 
+	r3: read(buffer, offset, len);
+	Read := r1 | r2 | r3;
 	
-	Close: close();
+	cl1: close();
+	Close := cl1;
 	
 ORDER
-	Cons, Reads+, Close
+	Con, Read+, Close
 
 CONSTRAINTS
-	len > off;
+	length[buffer] >= offset + len;
 	
 REQUIRES
-	generatedCipher[ciph];
+	generatedCipher[cipher];	
 	
 ENSURES
-	cipheredInputStream[is, ciph];
+	cipheredInputStream[inputStream, cipher];
 	

--- a/BouncyCastle-JCA/src/CipherOutputStream.crysl
+++ b/BouncyCastle-JCA/src/CipherOutputStream.crysl
@@ -1,34 +1,33 @@
 SPEC javax.crypto.CipherOutputStream
 
 OBJECTS
-	java.io.OutputStream os;
-	javax.crypto.Cipher ciph;
-	byte[] byte;
-	int off;
+	java.io.OutputStream outputStream;
+	javax.crypto.Cipher cipher;
+	byte[] data;
+	int offset;
 	int len;
-	int b;
+	int specifiedByte;
 	
 EVENTS
-	c1: CipherOutputStream(os);
-	c2: CipherOutputStream(os, ciph);
-	Cons := c1 | c2;
+	c1: CipherOutputStream(outputStream, cipher);
+	Con := c1;
 	
-	w1: write(b);
-	w2: write(byte);
-	w3: write(byte, off, len);
-	Writes := w1 | w2 | w3;
+	w1: write(specifiedByte);
+	w2: write(data);
+	w3: write(data, offset, len);
+	Write := w1 | w2 | w3;
 	
-	Close: close();
+	cl1: close();
+	Close := cl1;
 	
 ORDER
-	Cons, Writes+, Close
+	Con, Write+, Close
 	
 CONSTRAINTS
-	len > off;
+	length[data] >= offset + len;
 	
 REQUIRES
-	generatedCipher[ciph];
-	
+	generatedCipher[cipher];	
+
 ENSURES
-	cipheredOutputStream[os, ciph];
-	
+	cipheredOutputStream[outputStream, cipher];

--- a/BouncyCastle-JCA/src/DHGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DHGenParameterSpec.crysl
@@ -5,11 +5,11 @@ OBJECTS
 	int exponentSize;
 	
 EVENTS
-	Con: DHGenParameterSpec(primeSize, exponentSize);	
-	
+	c1: DHGenParameterSpec(primeSize, exponentSize);
+	Con := c1;
+
 ORDER
 	Con
-	
+
 ENSURES
 	preparedDH[this];
-	

--- a/BouncyCastle-JCA/src/DHGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DHGenParameterSpec.crysl
@@ -10,6 +10,9 @@ EVENTS
 
 ORDER
 	Con
+	
+CONSTRAINTS
+	exponentSize < primeSize;
 
 ENSURES
 	preparedDH[this];

--- a/BouncyCastle-JCA/src/DHParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DHParameterSpec.crysl
@@ -8,10 +8,10 @@ OBJECTS
 EVENTS
 	c1: DHParameterSpec(p, g);
 	c2: DHParameterSpec(p, g, l);
-	Cons := c1 | c2;
+	Con := c1 | c2;
 	
 ORDER
-	Cons
+	Con
 
 CONSTRAINTS
 	p >= 1^2048;

--- a/BouncyCastle-JCA/src/DSAGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DSAGenParameterSpec.crysl
@@ -13,5 +13,13 @@ EVENTS
 ORDER
 	Con
 	
+CONSTRAINTS
+	primePLen in {1024, 2048, 3072};
+	subPrimeQLen in {160, 224, 256};
+	
+	primePLen in {1024} => subPrimeQLen in {160};
+	primePLen in {2048} => subPrimeQLen in {224, 256};
+	primePLen in {3072} => subPrimeQLen in {256};
+	
 ENSURES
 	preparedDSA[this];

--- a/BouncyCastle-JCA/src/DSAGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DSAGenParameterSpec.crysl
@@ -8,11 +8,10 @@ OBJECTS
 EVENTS
 	c1: DSAGenParameterSpec(primePLen, subPrimeQLen);
 	c2: DSAGenParameterSpec(primePLen, subPrimeQLen, seedLen);
-	Cons := c1 | c2;
+	Con := c1 | c2;
 	
 ORDER
-	Cons
+	Con
 	
 ENSURES
 	preparedDSA[this];
-	

--- a/BouncyCastle-JCA/src/DSAParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DSAParameterSpec.crysl
@@ -6,7 +6,8 @@ OBJECTS
 	java.math.BigInteger g;
 	
 EVENTS
-	Con: DSAParameterSpec(p, q, g);
+	c1: DSAParameterSpec(p, q, g);
+	Con := c1;
 	
 ORDER
 	Con

--- a/BouncyCastle-JCA/src/DigestInputStream.crysl
+++ b/BouncyCastle-JCA/src/DigestInputStream.crysl
@@ -1,8 +1,8 @@
 SPEC java.security.DigestInputStream
 
 OBJECTS
-	java.io.InputStream is;
-	java.security.MessageDigest md;
+	java.io.InputStream stream;
+	java.security.MessageDigest digest;
 	byte[] data;
 	int offset;
 	int len;
@@ -11,23 +11,26 @@ FORBIDDEN
 	on(boolean) ;
 
 EVENTS
-	Con: DigestInputStream(is, md);
+	c1: DigestInputStream(stream, digest);
+	Con := c1;
 	
 	r1: read(); 
 	r2: read(data, offset, len);
-	Reads := r1 | r2;
+	Read := r1 | r2;
 
-	Close: close();
+	cl1: close();
+	Close := cl1;
 
 ORDER
-	Con, Reads+, Close
+	Con, Read+, Close
 	
 CONSTRAINTS
-	len > offset;
+	length[data] >= offset + len;
 	
 REQUIRES
-	generatedMessageDigest[md];
+	generatedMessageDigest[digest];
 
 ENSURES
-	digestedInputStream[is, md];
+	digestedInputStream[stream, digest];
+
 	

--- a/BouncyCastle-JCA/src/DigestOutputStream.crysl
+++ b/BouncyCastle-JCA/src/DigestOutputStream.crysl
@@ -1,8 +1,8 @@
 SPEC java.security.DigestOutputStream
 
 OBJECTS
-	java.io.OutputStream os;
-	java.security.MessageDigest md;
+	java.io.OutputStream stream;
+	java.security.MessageDigest digest;
 	byte[] data;
 	int offset;
 	int len;
@@ -12,23 +12,24 @@ FORBIDDEN
 	on(boolean) ;
 
 EVENTS
-	Con: DigestOutputStream(os, md);
+	c1: DigestOutputStream(stream, digest);
+	Con := c1;
 	
 	r1: write(specifiedByte); 
 	r2: write(data, offset, len);
-	Writes := r1 | r2;
+	Write := r1 | r2;
 
-	Close: close();
+	cl1: close();
+	Close := cl1;
 
 ORDER
-	Con, Writes+, Close
+	Con, Write+, Close
 	
 CONSTRAINTS
-	len > offset;
+	length[data] >= offset + len;
 	
 REQUIRES
-	generatedMessageDigest[md];
+	generatedMessageDigest[digest];
 	
 ENSURES
-	digestedOutputStream[os, md];
-	
+	digestedOutputStream[stream, digest];

--- a/BouncyCastle-JCA/src/ECGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/ECGenParameterSpec.crysl
@@ -1,0 +1,25 @@
+SPEC java.security.spec.ECGenParameterSpec
+
+OBJECTS 
+	java.lang.String stdName;
+	
+EVENTS
+	c1: ECGenParameterSpec(stdName);
+	Con := c1;
+
+ORDER
+	Con
+	
+CONSTRAINTS
+	stdName in {"brainpoolP224r1", "1.3.36.3.3.2.8.1.1.5",
+			"brainpoolP256r1", "1.3.36.3.3.2.8.1.1.7",
+			"brainpoolP320r1", "1.3.36.3.3.2.8.1.1.9",
+			"brainpoolP384r1", "1.3.36.3.3.2.8.1.1.11",
+			"brainpoolP512r1", "1.3.36.3.3.2.8.1.1.13",
+			"secp224r1", "NIST P-224", "1.3.132.0.33",
+			"secp256r1", "NIST P-256", "X9.62 prime256v1" ,"1.2.840.10045.3.1.7",
+			"secp384r1", "NIST P-384", "1.3.132.0.34",
+			"secp521r1", "NIST P-521", "1.3.132.0.35"};
+
+ENSURES
+	preparedEC[this];

--- a/BouncyCastle-JCA/src/ECParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/ECParameterSpec.crysl
@@ -1,0 +1,17 @@
+SPEC java.security.spec.ECParameterSpec
+
+OBJECTS 
+	java.security.spec.EllipticCurve curve;
+	java.security.spec.ECPoint g;
+	java.math.BigInteger n;
+	int h;
+	
+EVENTS
+	c1: ECParameterSpec(curve, g, n, h);	
+	Con := c1;
+
+ORDER
+	Con
+
+ENSURES
+	preparedEC[this];

--- a/BouncyCastle-JCA/src/GCMParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/GCMParameterSpec.crysl
@@ -1,25 +1,26 @@
 SPEC javax.crypto.spec.GCMParameterSpec
 
 OBJECTS 
-	int tLen;
+	int tagLen;
 	byte[] src;
 	int offset;
 	int len;
 	
 EVENTS
-	c1: GCMParameterSpec(tLen, src);
-	c2: GCMParameterSpec(tLen, src, offset, len);
-	Cons := c1 | c2;
+	c1: GCMParameterSpec(tagLen, src);
+	c2: GCMParameterSpec(tagLen, src, offset, len);
+	Con := c1 | c2;
 	
 ORDER
-	Cons
+	Con
 	
 CONSTRAINTS
-	tLen in {96, 104, 112, 120, 128};
+	tagLen in {96, 104, 112, 120, 128};
+	length[src] >= offset + len;
 	
 REQUIRES
 	randomized[src];
 	
 ENSURES
 	preparedGCM[this];
-	
+

--- a/BouncyCastle-JCA/src/HMACParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/HMACParameterSpec.crysl
@@ -1,14 +1,14 @@
 SPEC javax.xml.crypto.dsig.spec.HMACParameterSpec
 
 OBJECTS 
-	int outputLength;
-	
+	int outputLen;
+
 EVENTS
-	Con: HMACParameterSpec(outputLength);
+	c1: HMACParameterSpec(outputLen);
+	Con := c1;
 	
 ORDER
 	Con
 	
 ENSURES
 	preparedHMAC[this];
-	

--- a/BouncyCastle-JCA/src/IvParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/IvParameterSpec.crysl
@@ -6,16 +6,20 @@ OBJECTS
 	int len;
 	
 EVENTS
-	cons1: IvParameterSpec(iv);
-	cons2: IvParameterSpec(iv, offset, len);
-	Cons := cons1 | cons2;
+	c1: IvParameterSpec(iv);
+	c2: IvParameterSpec(iv, offset, len);
+	Con := c1 | c2;
 	
 ORDER
-	Cons
+	Con
+	
+CONSTRAINTS
+	length[iv] >= offset + len;
 	
 REQUIRES
 	randomized[iv];
-	
+
 ENSURES
 	preparedIV[this];
+
 	

--- a/BouncyCastle-JCA/src/Key.crysl
+++ b/BouncyCastle-JCA/src/Key.crysl
@@ -4,7 +4,8 @@ OBJECTS
 	byte[] keyMaterial;
 	
 EVENTS
-	GetEnc: keyMaterial = getEncoded();
+	ge1: keyMaterial = getEncoded();
+	GetEnc := ge1;
 	
 ORDER
 	GetEnc*

--- a/BouncyCastle-JCA/src/KeyAgreement.crysl
+++ b/BouncyCastle-JCA/src/KeyAgreement.crysl
@@ -36,6 +36,7 @@ CONSTRAINTS
 	
 REQUIRES
 	randomized[random];
+	generatedPrivkey[key];
     
 ENSURES 
 	agreedKey[key, algorithm];

--- a/BouncyCastle-JCA/src/KeyAgreement.crysl
+++ b/BouncyCastle-JCA/src/KeyAgreement.crysl
@@ -5,33 +5,34 @@ OBJECTS
 	java.security.Key key;
 	boolean lastPhase;
 	byte[] sharedSecret;
-	int offset;
+	int off;
 	java.security.spec.AlgorithmParameterSpec params;
 	java.security.SecureRandom random;
 	
 EVENTS
 	g1: getInstance(algorithm);
 	g2: getInstance(algorithm, _);
-	Gets := g1 | g2;
+	Get := g1 | g2;
     
 	i1: init(key);
 	i2: init(key, params);
 	i3: init(key, params, random);
 	i4: init(key, random);
-	Inits := i1 | i2 | i3 | i4;
+	Init := i1 | i2 | i3 | i4;
     
-	DoPhase: doPhase(key, lastPhase);
+	dp1: doPhase(key, lastPhase);
+	DoPhase := dp1;
     
 	gs1: generateSecret();
-	gs2: generateSecret(sharedSecret, offset);
+	gs2: generateSecret(sharedSecret, off);
 	gs3: generateSecret(algorithm);
-	GenSecrets := gs1 | gs2 | gs3;
+	GenSecret := gs1 | gs2 | gs3;
     
 ORDER
-	Gets, Inits, DoPhase, GenSecrets
+	Get, Init, DoPhase, GenSecret
 	
 CONSTRAINTS
-	algorithm in {"DH", "DiffieHellman", "NH"};
+	algorithm in {"DH", "DiffieHellman", "NH" ,"ECDH", "ECDHC"};
 	
 REQUIRES
 	randomized[random];

--- a/BouncyCastle-JCA/src/KeyFactory.crysl
+++ b/BouncyCastle-JCA/src/KeyFactory.crysl
@@ -18,7 +18,7 @@ EVENTS
 	GenPubl := gpu1;
     
 ORDER
-	Get, (GenPriv* | GenPubl*)*
+	Get, (GenPriv | GenPubl)*
 
 CONSTRAINTS
 	algorithm in {"DiffieHellman", "DH", "DSA", "EC", "ECDH", "ECDHC", "ECDSA", "RSA", "ElGamal",

--- a/BouncyCastle-JCA/src/KeyFactory.crysl
+++ b/BouncyCastle-JCA/src/KeyFactory.crysl
@@ -1,32 +1,35 @@
 SPEC java.security.KeyFactory
 
 OBJECTS
-	java.lang.String keyFactoryAlgorithm;
+	java.lang.String algorithm;
 	java.security.spec.KeySpec keySpec;
-	java.security.PrivateKey privKey;
-	java.security.PublicKey pubKey;
+	java.security.PrivateKey privateKey;
+	java.security.PublicKey publicKey;
    
 EVENTS
-	g1: getInstance(keyFactoryAlgorithm);
-	g2: getInstance(keyFactoryAlgorithm, _);
-	Gets := g1 | g2;
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
+	Get := g1 | g2;
 
-	GenPriv: privKey = generatePrivate(keySpec);
-	GenPubl: pubKey = generatePublic(keySpec);    
+	gpr1: privateKey = generatePrivate(keySpec);
+	GenPriv := gpr1;
+	
+	gpu1: publicKey = generatePublic(keySpec);
+	GenPubl := gpu1;
     
 ORDER
-	Gets, (GenPriv* | GenPubl*)*
+	Get, (GenPriv* | GenPubl*)*
 
 CONSTRAINTS
-	keyFactoryAlgorithm in {"DiffieHellman", "DH", "DSA", "EC", "ECDH", "ECDHC", "ECDSA", "RSA", "ElGamal", 
-				"McElieceKobaraImai", "McEliecePointcheval", "McElieceFujisaki", "McEliece", "McEliece-CCA2", 
-				"NH", "QTESLA", "Rainbow", "SPHINCS256", "XMSS", "XMSSMT"};
+	algorithm in {"DiffieHellman", "DH", "DSA", "EC", "ECDH", "ECDHC", "ECDSA", "RSA", "ElGamal",
+				"X.509", "McElieceKobaraImai", "McEliecePointcheval", "McElieceFujisaki", "McEliece",
+				"McEliece-CCA2", "NH", "QTESLA", "Rainbow", "SPHINCS256", "XMSS", "XMSSMT"};
 
 REQUIRES
 	speccedKey[keySpec, _];	
 	
 ENSURES
-	generatedKeyFactory[this, keyFactoryAlgorithm] after Gets;
-	generatedPrivkey[privKey] after GenPriv;
-	generatedPubkey[pubKey] after GenPubl;
+	generatedKeyFactory[this, algorithm] after Get;
+	generatedPrivkey[privateKey] after GenPriv;
+	generatedPubkey[publicKey] after GenPubl;
     

--- a/BouncyCastle-JCA/src/KeyGenerator.crysl
+++ b/BouncyCastle-JCA/src/KeyGenerator.crysl
@@ -1,40 +1,42 @@
 SPEC javax.crypto.KeyGenerator
 
 OBJECTS
-	int secretKeySize;
+	int keysize;
 	java.security.spec.AlgorithmParameterSpec params;
 	javax.crypto.SecretKey key;
-	java.lang.String secretKeyAlgorithm;
-	java.security.SecureRandom ranGen;
+	java.lang.String algorithm;
+	java.security.SecureRandom random;
 
 EVENTS
-	g1: getInstance(secretKeyAlgorithm);
-	g2: getInstance(secretKeyAlgorithm, _);
-	Gets := g1 | g2;
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
+	Get := g1 | g2;
 
-	i1: init(secretKeySize);
-	i2: init(secretKeySize, ranGen);
+	i1: init(keysize);
+	i2: init(keysize, random);
 	i3: init(params);
-	i4: init(params, ranGen);
-	i5: init(ranGen);
-	Inits := i1 | i2 | i3 | i4 | i5;
+	i4: init(params, random);
+	i5: init(random);
+	Init := i1 | i2 | i3 | i4 | i5;
     
-	GenKey: key = generateKey();
+	gk1: key = generateKey();
+	GenKey := gk1;
 
 ORDER
-	Gets, Inits?, GenKey
+	Get, Init?, GenKey
 
 CONSTRAINTS
-	secretKeyAlgorithm in {"AES", "HmacSHA224", "HmacSHA256", "HmacSHA384", "HmacSHA512", "Poly1305-AES", "Poly1305-Camellia", "Camellia", "ChaCha", 
+	algorithm in {"AES", "HmacSHA224", "HmacSHA256", "HmacSHA384", "HmacSHA512", "HMACSHA3-224", "HMACSHA3-256", "HMACSHA3-384", "HMACSHA3-512",
+				"Poly1305-AES", "Poly1305-Camellia", "Camellia", "ChaCha", 
 				"ChaCha7539", "Poly1305", "Rijndael", "Salsa20", "Serpent", "Tnepres", "Poly1305-Serpent", "SHACAL-2", "Shacal2", 
 				"Twofish", "Poly1305-Twofish", "XSalsa20"};
-	secretKeyAlgorithm in {"AES", "Poly1305-Camellia", "Camellia", "ChaCha", "Salsa20", "SHACAL-2", "Shacal2",
+	algorithm in {"AES", "Poly1305-Camellia", "Camellia", "ChaCha", "Salsa20", "SHACAL-2", "Shacal2",
 				"Rijndael", "Serpent", "Tnepres", "ChaCha7539", "Poly1305", "Poly1305-Serpent", 
-				"Twofish", "Poly1305-Twofish", "XSalsa20"} => secretKeySize in {128, 192, 256};
+				"Twofish", "Poly1305-Twofish", "XSalsa20"} => keysize in {128, 192, 256};
 
 REQUIRES
-	randomized[ranGen];
+	randomized[random];
     
 ENSURES 
-	generatedKey[key, secretKeyAlgorithm];
+	generatedKey[key, algorithm];
     

--- a/BouncyCastle-JCA/src/KeyManagerFactory.crysl
+++ b/BouncyCastle-JCA/src/KeyManagerFactory.crysl
@@ -2,35 +2,36 @@ SPEC javax.net.ssl.KeyManagerFactory
 
 OBJECTS
 	char[] password;
-	java.lang.String algo;
+	java.lang.String algorithm;
 	java.security.KeyStore keyStore;
 	javax.net.ssl.ManagerFactoryParameters params;
-	javax.net.ssl.KeyManager[] kms;
+	javax.net.ssl.KeyManager[] keyManager;
 	
 EVENTS 
-	g1: getInstance(algo);
-	g2: getInstance(algo, _);
-	Gets := g1 | g2;
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
+	Get := g1 | g2;
 
 	i1: init(keyStore, password);
 	i2: init(params);
-	Inits := i1 | i2;
+	Init := i1 | i2;
 	
-	GetKeyMng: kms = getKeyManagers();
+	gkm1: keyManager = getKeyManagers();
+	GetKeyMng := gkm1;
 			
 ORDER
-	Gets, Inits, GetKeyMng?
+	Get, Init, GetKeyMng?
 
 CONSTRAINTS
 	neverTypeOf[password, java.lang.String];
 	notHardCoded[password];
-	algo in {"PKIX", "X509", "X.509"};
+	algorithm in {"PKIX", "X509", "X.509"};
 
 REQUIRES
 	generatedKeyStore[keyStore];
 	generatedManagerFactoryParameters[params];
 	
 ENSURES
-	generatedKeyManager[this] after Inits;
-	generatedKeyManagers[kms] after GetKeyMng;
+	generatedKeyManager[this] after Init;
+	generatedKeyManagers[keyManager] after GetKeyMng;
 	

--- a/BouncyCastle-JCA/src/KeyPair.crysl
+++ b/BouncyCastle-JCA/src/KeyPair.crysl
@@ -1,26 +1,29 @@
 SPEC java.security.KeyPair
 
 OBJECTS
-	java.security.PrivateKey consPriv;
-	java.security.PublicKey consPub;
-	java.security.PrivateKey retPriv;
-	java.security.PublicKey retPub;
+	java.security.PrivateKey privateKey;
+	java.security.PublicKey publicKey;
+	java.security.PrivateKey retPrivateKey;
+	java.security.PublicKey retPublicKey;
 	
 EVENTS
-	Con: KeyPair(consPub, consPriv);
+	c1: KeyPair(publicKey, privateKey);
+	Con := c1;
 	
-	GetPubl: retPub = getPublic();
-	GetPriv: retPriv = getPrivate();
+	gpu1: retPublicKey = getPublic();
+	GetPubl := gpu1;
+	
+	gpr1: retPrivateKey = getPrivate();
+	GetPriv := gpr1;
 
 ORDER
 	Con, (GetPubl*, GetPriv*)*
 	
 REQUIRES
-	generatedPrivkey[consPriv];
-	generatedPubkey[consPub];
+	generatedPrivkey[privateKey];
+	generatedPubkey[publicKey];
 	
 ENSURES
 	generatedKeypair[this, _] after Con;
-	generatedPubkey[retPub] after GetPubl;
-	generatedPrivkey[retPriv] after GetPriv;
-	
+	generatedPubkey[retPublicKey] after GetPubl;
+	generatedPrivkey[retPrivateKey] after GetPriv;

--- a/BouncyCastle-JCA/src/KeyPair.crysl
+++ b/BouncyCastle-JCA/src/KeyPair.crysl
@@ -17,7 +17,7 @@ EVENTS
 	GetPriv := gpr1;
 
 ORDER
-	Con, (GetPubl*, GetPriv*)*
+	Con, (GetPubl | GetPriv)*
 	
 REQUIRES
 	generatedPrivkey[privateKey];

--- a/BouncyCastle-JCA/src/KeyPairGenerator.crysl
+++ b/BouncyCastle-JCA/src/KeyPairGenerator.crysl
@@ -1,45 +1,45 @@
 SPEC java.security.KeyPairGenerator
 
 OBJECTS
-	java.lang.String keyPairAlgorithm;
-	java.security.KeyPair kp;
+	java.lang.String algorithm;
+	java.security.KeyPair keyPair;
 	java.security.spec.AlgorithmParameterSpec params;
-	int keyPairSize;
+	int keysize;
 
 EVENTS
-	g1:getInstance(keyPairAlgorithm);
-	g2:getInstance(keyPairAlgorithm, _);
-	Gets := g1 | g2;
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
+	Get := g1 | g2;
 
-	i1: initialize(keyPairSize);
-	i2: initialize(keyPairSize, _);
+	i1: initialize(keysize);
+	i2: initialize(keysize, _);
 	i3: initialize(params);
 	i4: initialize(params, _);
-	Inits := i1 | i2 | i3 | i4;
+	Init := i1 | i2 | i3 | i4;
 
-	k1: kp = generateKeyPair();
-	k2: kp = genKeyPair();
-	Gens := k1 | k2;
+	k1: keyPair = generateKeyPair();
+	k2: keyPair = genKeyPair();
+	Gen := k1 | k2;
 
 ORDER
-	Gets, Inits, Gens
+	Get, Init, Gen
 
 CONSTRAINTS
-	keyPairAlgorithm in {"RSA", "DSA", "DiffieHellman", "DH", "EC", "ECDSA", "ECDH", "ECDHWITHSHA1KDF", "ECDHC", 
+	algorithm in {"RSA", "DSA", "DiffieHellman", "DH", "EC", "ECDSA", "ECDH", "ECDHWITHSHA1KDF", "ECDHC", 
 			"ECIES", "ElGamal", "McElieceKobaraImai", "McEliecePointcheval", "McElieceFujisaki", 
 			"McEliece", "McEliece-CCA2", "NH", "QTESLA", "Rainbow", "SPHINCS256", "XMSS", "XMSSMT"};
 						
-	keyPairAlgorithm in {"RSA"} => keyPairSize in {4096, 3072, 2048};
-	keyPairAlgorithm in {"DSA"} => keyPairSize in {2048};
-	keyPairAlgorithm in {"DiffieHellman", "DH"} => keyPairSize in {2048};
-	keyPairAlgorithm in {"EC", "ECDSA", "ECDH", "ECDHWITHSHA1KDF", "ECDHC", "ECIES"} => keyPairSize in {256};
+	algorithm in {"RSA"} => keysize in {4096, 3072, 2048};
+	algorithm in {"DSA"} => keysize in {2048};
+	algorithm in {"DiffieHellman", "DH"} => keysize in {2048};
+	algorithm in {"EC", "ECDSA", "ECDH", "ECDHWITHSHA1KDF", "ECDHC", "ECIES"} => keysize in {256};
 	
 REQUIRES
-	keyPairAlgorithm in {"RSA"} => preparedRSA[params];
-	keyPairAlgorithm in {"DSA"} => preparedDSA[params];
-	keyPairAlgorithm in {"DiffieHellman", "DH"} => preparedDH[params];
-	keyPairAlgorithm in {"EC"} => preparedEC[params];
+	algorithm in {"RSA"} => preparedRSA[params];
+	algorithm in {"DSA"} => preparedDSA[params];
+	algorithm in {"DiffieHellman", "DH"} => preparedDH[params];
+	algorithm in {"EC"} => preparedEC[params];
 
 ENSURES
-	generatedKeypair[kp, keyPairAlgorithm];
+	generatedKeypair[keyPair, algorithm];
     

--- a/BouncyCastle-JCA/src/KeyStore.crysl
+++ b/BouncyCastle-JCA/src/KeyStore.crysl
@@ -1,7 +1,7 @@
 SPEC java.security.KeyStore 
 
 OBJECTS
-	java.io.InputStream fileinput;
+	java.io.InputStream fileInput;
     
 	char[] passwordIn;
 	char[] passwordOut;
@@ -15,9 +15,9 @@ OBJECTS
 	java.security.KeyStore.ProtectionParameter protParamSet;
 	java.lang.String aliasGet;
 	java.lang.String aliasSet;
-	java.io.OutputStream fileoutput;
+	java.io.OutputStream fileOutput;
 	java.security.KeyStore.LoadStoreParameter paramStore;
-	java.lang.String keyStoreAlgorithm;
+	java.lang.String type;
 	java.security.cert.Certificate[] chain;
 	java.security.cert.Certificate cert;
     
@@ -25,36 +25,39 @@ OBJECTS
 	java.lang.String alias;
     
 EVENTS
-	g1: getInstance(keyStoreAlgorithm);
-	g2: getInstance(keyStoreAlgorithm, _);
-	Gets := g1 | g2;
+	g1: getInstance(type);
+	g2: getInstance(type, _);
+	Get := g1 | g2;
 
-	l1: load(fileinput, passwordIn);
+	l1: load(fileInput, passwordIn);
 	l2: load(paramLoad);
-	Loads := l1 | l2;
+	Load := l1 | l2;
 
-	s1:store(paramStore);
-	s2:store(fileoutput, passwordOut);
-	Stores := s1 | s2;
+	s1: store(paramStore);
+	s2: store(fileOutput, passwordOut);
+	Store := s1 | s2;
 
-	GetEntry: getEntry(aliasGet, protParamGet);
+	ge1: getEntry(aliasGet, protParamGet);
+	GetEntry := ge1;
     
-	SetEntry: setEntry(aliasSet, entry, protParamSet);
+	se1: setEntry(aliasSet, entry, protParamSet);
+	SetEntry := se1;
         
-	GetKey: key = getKey(alias, passwordKey);
+	gk1: key = getKey(alias, passwordKey);
+	GetKey := gk1;
 
 ORDER
-	Gets, Loads, ((GetEntry?, GetKey) | (SetEntry, Stores))*
+	Get, Load, ((GetEntry?, GetKey) | (SetEntry, Store))*
 
 CONSTRAINTS
-	keyStoreAlgorithm in {"BCFKS", "BCFKS-DEF", "IBCFKS", "IBCFKS-DEF"};
+	type in {"BCFKS", "BCFKS-DEF", "IBCFKS", "IBCFKS-DEF"};
 	neverTypeOf[passwordIn, java.lang.String];
 	neverTypeOf[passwordOut, java.lang.String];
 	neverTypeOf[passwordKey, java.lang.String];
 	notHardCoded[passwordIn];
 
 ENSURES
-	generatedKeyStore[this] after Loads;
+	generatedKeyStore[this] after Load;
 	generatedKey[key, _];
 	generatedPrivkey[key];
 	generatedPubkey[key];

--- a/BouncyCastle-JCA/src/KeyStore.crysl
+++ b/BouncyCastle-JCA/src/KeyStore.crysl
@@ -18,7 +18,6 @@ OBJECTS
 	java.io.OutputStream fileOutput;
 	java.security.KeyStore.LoadStoreParameter paramStore;
 	java.lang.String type;
-	java.security.cert.Certificate[] chain;
 	java.security.cert.Certificate cert;
     
 	java.security.Key key;

--- a/BouncyCastle-JCA/src/KeyStoreBuilderParameters.crysl
+++ b/BouncyCastle-JCA/src/KeyStoreBuilderParameters.crysl
@@ -4,7 +4,8 @@ OBJECTS
 	java.security.KeyStore.Builder builder;
 	
 EVENTS
-	Con: KeyStoreBuilderParameters(builder);
+	c1: KeyStoreBuilderParameters(builder);
+	Con := c1;
 	
 ORDER
 	Con

--- a/BouncyCastle-JCA/src/MGF1ParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/MGF1ParameterSpec.crysl
@@ -1,0 +1,17 @@
+SPEC java.security.spec.MGF1ParameterSpec
+
+OBJECTS 
+	java.lang.String mdName;
+
+EVENTS
+	c1: MGF1ParameterSpec(mdName);
+	Con := c1;
+	
+ORDER
+	Con
+
+CONSTRAINTS
+	mdName in {"SHA-256", "SHA-384", "SHA-512"};
+
+ENSURES
+	preparedMGF1[this, mdName];

--- a/BouncyCastle-JCA/src/Mac.crysl
+++ b/BouncyCastle-JCA/src/Mac.crysl
@@ -3,45 +3,46 @@ SPEC javax.crypto.Mac
 OBJECTS
 	javax.crypto.Mac mac;
 	java.security.Key key;
-	byte inp;
-	byte[] pre_input;
+	byte inputByte;
+	byte[] preInput;
 	byte[] input;
 	byte[] output1;
 	byte[] output2;
-	java.lang.String macAlgorithm;
+	java.nio.ByteBuffer preInputByteBuffer;
+	java.lang.String algorithm;
 	java.security.spec.AlgorithmParameterSpec params;
 	int offset;
 	int outOffset;
 	int len;
 
 EVENTS
-	g1: getInstance(macAlgorithm);
-	g2: getInstance(macAlgorithm, _);
-	Gets := g1 | g2;
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
+	Get := g1 | g2;
 
 	i1: init(key);
 	i2: init(key, params);
-	Inits := i1 | i2;
+	Init := i1 | i2;
 
-	u1: update(inp);
-	u2: update(pre_input);
-	u3: update(pre_input, offset, len);
-	u4: update(pre_input);
-	Updates := u1 | u2 | u3 | u4;
+	u1: update(inputByte);
+	u2: update(preInput);
+	u3: update(preInput, offset, len);
+	u4: update(preInputByteBuffer);
+	Update := u1 | u2 | u3 | u4;
 
 	f1: output1 = doFinal();
 	f2: output2 = doFinal(input);
 	f3: doFinal(output1, outOffset);
-	FinalsWU := f1 | f3;
-	Finals := FinalsWU | f2;
+	FinalWU := f1 | f3;
+	Final := FinalWU | f2;
 
 ORDER
-	Gets, Inits, (FinalsWU | (Updates+, Finals))
+	Get, Init, (FinalWU | (Update+, Final))
 
 CONSTRAINTS
-	macAlgorithm in {"AESCMAC", "AESCCMMAC", "HmacSHA256", "HmacSHA384", "HmacSHA512", "PBEWithHmacSHA256", 
-			"PBEWithHmacSHA384", "PBEWithHmacSHA512", "Poly1305", "Shacal-2CMAC"};
-	offset < len;
+	algorithm in {"AESCMAC", "AESCCMMAC", "HmacSHA256", "HmacSHA384", "HmacSHA512",
+			 "HMACSHA3-256", "HMACSHA3-384", "HMACSHA3-512",
+			 "PBEWithHmacSHA256", "PBEWithHmacSHA384", "PBEWithHmacSHA512", "Poly1305", "Shacal-2CMAC"};
 	length[output1] > outOffset;
     
 REQUIRES
@@ -51,6 +52,6 @@ REQUIRES
 	generatedKey[key,_];
 
 ENSURES
-	macced[output1, inp];
-	macced[output1, pre_input];
+	macced[output1, inputByte];
+	macced[output1, preInput];
 	macced[output2, input];

--- a/BouncyCastle-JCA/src/MessageDigest.crysl
+++ b/BouncyCastle-JCA/src/MessageDigest.crysl
@@ -1,45 +1,49 @@
 SPEC java.security.MessageDigest
 
 OBJECTS
-	java.lang.String digestAlgorithm;
-	byte pre_inbyte;
-	byte[] pre_inbytearr;
-	int pre_off;
-	int pre_len;
-	java.nio.ByteBuffer pre_inpBuf;
-	byte[] inbytearr;
-	int off;
+	java.lang.String algorithm;
+	byte preInputByte;
+	byte[] preInput;
+	int preOffset;
+	int preLen;
+	java.nio.ByteBuffer preInputByteBuffer;
+	byte[] input;
+	int offset;
 	int len;
-	byte[] out;
+	byte[] output;
 	
 EVENTS
-	g1: getInstance(digestAlgorithm);
-	g2: getInstance(digestAlgorithm, _);
-	Gets := g1 | g2;
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
+	Get := g1 | g2;
 
-	u1: update(pre_inbyte);
-	u2: update(pre_inbytearr);
-	u3: update(pre_inbytearr, pre_off, pre_len);
-	u4: update(pre_inpBuf);
-	Updates := u1 | u2 | u3 | u4;
+	u1: update(preInputByte);
+	u2: update(preInput);
+	u3: update(preInput, preOffset, preLen);
+	u4: update(preInputByteBuffer);
+	Update := u1 | u2 | u3 | u4;
 
-	d1: out = digest();
-	d2: out = digest(inbytearr);
-	d3: digest(out, off, len);
+	d1: output = digest();
+	d2: output = digest(input);
+	d3: digest(output, offset, len);
 	DWOU := d2;
 	DWU := d1 | d3;
-	Digests := DWU | DWOU;
+	Digest := DWU | DWOU;
 
 ORDER
-	Gets, (DWOU | (Updates+, Digests))+
+	Get, (DWOU | (Update+, Digest))+
 
 CONSTRAINTS
-	digestAlgorithm in {"SHA-256", "SHA-384", "SHA-512", "SHA-512/256", "BLAKE2B-256", "BLAKE2B-384", 
-			"BLAKE2B-512", "BLAKE2S-256", "KECCAK-256", "KECCAK-384", "KECCAK-512", "WHIRLPOOL"};
-	length[pre_inbytearr] >= pre_len + pre_off;
-	length[out] >= len + off;
+	algorithm in {"SHA-256", "SHA-384", "SHA-512", "SHA-512/256", "SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512",
+			"BLAKE2B-256", "BLAKE2B-384", "BLAKE2B-512", "BLAKE2S-256",
+			"KECCAK-256", "KECCAK-384", "KECCAK-512",
+			"WHIRLPOOL"};
+	length[preInput] >= preLen + preOffset;
+	length[output] >= len + offset;
 
 ENSURES
-	generatedMessageDigest[this] after Gets;
-	digested[out, _];
-	digested[out, inbytearr];
+	generatedMessageDigest[this] after Get;
+	digested[output, _];
+	digested[output, input];
+
+

--- a/BouncyCastle-JCA/src/OAEPParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/OAEPParameterSpec.crysl
@@ -1,0 +1,25 @@
+SPEC javax.crypto.spec.OAEPParameterSpec
+
+OBJECTS 
+	java.lang.String mdName;
+	java.lang.String mgfName;
+	java.security.spec.AlgorithmParameterSpec mgfSpec;
+	javax.crypto.spec.PSource pSrc;
+	java.lang.String alg;
+
+EVENTS
+	c1: OAEPParameterSpec(mdName, mgfName, mgfSpec, pSrc);
+	Con := c1;
+
+ORDER
+	Con
+
+CONSTRAINTS
+	mdName in {"SHA-256", "SHA-384", "SHA-512"};
+	mgfName in {"MGF1"};
+	
+REQUIRES
+	preparedMGF1[mgfSpec, mdName];
+
+ENSURES
+	preparedOAEP[this];

--- a/BouncyCastle-JCA/src/PBEKeySpec.crysl
+++ b/BouncyCastle-JCA/src/PBEKeySpec.crysl
@@ -4,19 +4,21 @@ OBJECTS
 	char[] password;
 	byte[] salt;
 	int iterationCount;
-	int keylength; 
+	int keyLength; 
 	
 FORBIDDEN
 	PBEKeySpec(char[]) => Con;
 	PBEKeySpec(char[],byte[],int) => Con;
 	
 EVENTS
-	Con: PBEKeySpec(password, salt, iterationCount, keylength);
+	c1: PBEKeySpec(password, salt, iterationCount, keyLength);
+	Con := c1;
 	
-	ClearPass: clearPassword();
+	cp1: clearPassword();
+	ClearPass := cp1;
 	
 ORDER
- 	Con, ClearPass
+	Con, ClearPass
  	
 CONSTRAINTS
 	iterationCount >= 10000;
@@ -25,10 +27,11 @@ CONSTRAINTS
 
 REQUIRES
 	randomized[salt];	
-	
+
 ENSURES
-	speccedKey[this, keylength] after Con;
-	
+	speccedKey[this, keyLength] after Con;
+
 NEGATES
 	speccedKey[this, _] after ClearPass;
+
 	

--- a/BouncyCastle-JCA/src/PBEParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/PBEParameterSpec.crysl
@@ -3,22 +3,23 @@ SPEC javax.crypto.spec.PBEParameterSpec
 OBJECTS 
 	byte[] salt;
 	int iterationCount;
-	java.security.spec.AlgorithmParameterSpec paramSpec;
+	java.security.spec.AlgorithmParameterSpec params;
 	
 EVENTS
 	c1: PBEParameterSpec(salt, iterationCount);
-	c2: PBEParameterSpec(salt, iterationCount, paramSpec);
-	Cons := c1 | c2;
+	c2: PBEParameterSpec(salt, iterationCount, params);
+	Con := c1 | c2;
 	
 ORDER
-	Cons
+	Con
 	
 CONSTRAINTS
 	iterationCount >= 10000;	
 
 REQUIRES
 	randomized[salt];
-
+			
 ENSURES
 	preparedPBE[this];
+
 	

--- a/BouncyCastle-JCA/src/PKIXBuilderParameters.crysl
+++ b/BouncyCastle-JCA/src/PKIXBuilderParameters.crysl
@@ -1,20 +1,20 @@
 SPEC java.security.cert.PKIXBuilderParameters
 
 OBJECTS
-	java.security.KeyStore keyStore;
-	java.security.cert.CertSelector certSelector;
+	java.security.KeyStore keystore;
+	java.security.cert.CertSelector targetConstraints;
 	java.util.Set<java.security.cert.TrustAnchor> trustAnchors;
 
 EVENTS
-	c1: PKIXBuilderParameters(keyStore, certSelector);
-	c2: PKIXBuilderParameters(trustAnchors, certSelector);
-	Cons := c1 | c2;
+	c1: PKIXBuilderParameters(keystore, targetConstraints);
+	c2: PKIXBuilderParameters(trustAnchors, targetConstraints);
+	Con := c1 | c2;
 	
 ORDER
-	Cons
+	Con
 	
 REQUIRES
-	generatedKeyStore[keyStore];
+	generatedKeyStore[keystore];
 	
 ENSURES
 	generatedCertPathParameters[this];

--- a/BouncyCastle-JCA/src/PKIXParameters.crysl
+++ b/BouncyCastle-JCA/src/PKIXParameters.crysl
@@ -6,10 +6,10 @@ OBJECTS
 EVENTS
 	c1: PKIXParameters(keyStore);
 	c2: PKIXParameters(_);
-	Cons := c1 | c2;
+	Con := c1 | c2;
 	
 ORDER
-	Cons
+	Con
 
 REQUIRES
 	generatedKeyStore[keyStore];		

--- a/BouncyCastle-JCA/src/RSAKeyGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/RSAKeyGenParameterSpec.crysl
@@ -1,19 +1,19 @@
 SPEC java.security.spec.RSAKeyGenParameterSpec
 
 OBJECTS 
-	int keyLength;
+	int keysize;
 	java.math.BigInteger publicExponent;
 	
 EVENTS
-	Con: RSAKeyGenParameterSpec(keyLength, publicExponent);
+	c1: RSAKeyGenParameterSpec(keysize, publicExponent);
+	Con := c1;
 	
 ORDER
 	Con
 	
 CONSTRAINTS
-	keyLength in {1024, 2048, 4096};
+	keysize in {1024, 2048, 4096};
 	publicExponent in {65537};
 	 
 ENSURES
 	preparedRSA[this];
-	

--- a/BouncyCastle-JCA/src/SSLContext.crysl
+++ b/BouncyCastle-JCA/src/SSLContext.crysl
@@ -2,37 +2,37 @@ SPEC javax.net.ssl.SSLContext
  
 OBJECTS
 	java.lang.String protocol;
-	javax.net.ssl.KeyManager[] kms; 
-	javax.net.ssl.TrustManager[] tms; 
-	java.security.SecureRandom sr;
+	javax.net.ssl.KeyManager[] km; 
+	javax.net.ssl.TrustManager[] tm; 
 	javax.net.ssl.SSLEngine eng;
+	java.security.SecureRandom random;
 	
 FORBIDDEN
-	getDefault() => Gets;
+	getDefault() => Get;
 
 EVENTS
 	g1: getInstance(protocol);
 	g2: getInstance(protocol, _);
-	Gets := g1 | g2;
+	Get := g1 | g2;
 	
-	Init: init(kms, tms, sr);		
+	i1: init(km, tm, random);
+	Init := i1;		
 	
 	se1: eng = createSSLEngine();
 	se2: eng = createSSLEngine(_,_);
-	Engines := se1 | se2;
+	Engine := se1 | se2;
 
 ORDER
-	Gets, Init, Engines? 
+	Get, Init, Engine? 
 
 CONSTRAINTS
 	protocol in {"TLSv1.2"};
 
 REQUIRES
-	generatedKeyManagers[kms];
-	generatedTrustManagers[tms];
-	randomized[sr];
+	generatedKeyManagers[km];
+	generatedTrustManagers[tm];
+	randomized[random];
 	
 ENSURES
 	generatedSSLContext[this] after Init;
-	generatedSSLEngine[eng] after Engines;
-	
+	generatedSSLEngine[eng] after Engine;

--- a/BouncyCastle-JCA/src/SSLEngine.crysl
+++ b/BouncyCastle-JCA/src/SSLEngine.crysl
@@ -1,20 +1,22 @@
 SPEC javax.net.ssl.SSLEngine
 
 OBJECTS
-	java.lang.String[] ciphersuites;
+	java.lang.String[] cipherSuites;
 	java.lang.String[] protocols;
-	
+
 EVENTS
-	EnableCipher: setEnabledCipherSuites(ciphersuites);
+	ec1: setEnabledCipherSuites(cipherSuites);
+	EnableCipher := ec1;
 	
-	EnableProtocol: setEnabledProtocols(protocols);
+	ep1: setEnabledProtocols(protocols);
+	EnableProtocol := ep1;	
 	
 ORDER
 	(EnableCipher, EnableProtocol) | (EnableProtocol, EnableCipher) 
 
 CONSTRAINTS
 	elements(protocols) in {"TLSv1.2"};
-	elements(ciphersuites) in {"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+	elements(cipherSuites) in {"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
 				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 				"TLS_RSA_WITH_AES_256_GCM_SHA384",

--- a/BouncyCastle-JCA/src/SSLParameters.crysl
+++ b/BouncyCastle-JCA/src/SSLParameters.crysl
@@ -1,15 +1,15 @@
 SPEC javax.net.ssl.SSLParameters
 
 OBJECTS
-	java.lang.String[] ciphersuites;
+	java.lang.String[] cipherSuites;
 	java.lang.String[] protocols;
-	
+
 EVENTS
 	Con1: SSLParameters();
-	Con2: SSLParameters(ciphersuites);
-	Con3: SSLParameters(ciphersuites,protocols);
+	Con2: SSLParameters(cipherSuites);
+	Con3: SSLParameters(cipherSuites, protocols);
 	
-	CipherSuite: setCipherSuites(ciphersuites);
+	CipherSuite: setCipherSuites(cipherSuites);
 	SetProtocol: setProtocols(protocols);
 		
 	
@@ -18,7 +18,7 @@ ORDER
 		
 CONSTRAINTS
 	elements(protocols) in {"TLSv1.2"};
-	elements(ciphersuites) in {"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+	elements(cipherSuites) in {"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
 				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 				"TLS_RSA_WITH_AES_256_GCM_SHA384",

--- a/BouncyCastle-JCA/src/SecretKey.crysl
+++ b/BouncyCastle-JCA/src/SecretKey.crysl
@@ -5,16 +5,19 @@ OBJECTS
 	byte[] keyMaterial;
 	
 EVENTS
-	GetEnc: keyMaterial = getEncoded();
+	ge1: keyMaterial = getEncoded();
+	GetEnc := ge1;
 	
-	Destroy: destroy();
-	
+	d1: destroy();
+	Destroy := d1;
+
 ORDER
 	GetEnc*, Destroy?
-	
+			
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;
-	
+
 NEGATES
 	generatedKey[this, _] after Destroy;
+
 	

--- a/BouncyCastle-JCA/src/SecretKey.crysl
+++ b/BouncyCastle-JCA/src/SecretKey.crysl
@@ -1,7 +1,6 @@
 SPEC javax.crypto.SecretKey
 
 OBJECTS 
-	javax.crypto.SecretKey key;
 	byte[] keyMaterial;
 	
 EVENTS

--- a/BouncyCastle-JCA/src/SecretKeyFactory.crysl
+++ b/BouncyCastle-JCA/src/SecretKeyFactory.crysl
@@ -1,25 +1,25 @@
 SPEC javax.crypto.SecretKeyFactory
 
 OBJECTS
-	java.lang.String keyFactoryAlgorithm;
+	java.lang.String algorithm;
 	javax.crypto.SecretKey key;
 	javax.crypto.SecretKey otherKey;
 	java.security.spec.KeySpec keySpec;
    
 EVENTS
-	g1: getInstance(keyFactoryAlgorithm);
-	g2: getInstance(keyFactoryAlgorithm, _);
-	Gets := g1 | g2;
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
+	Get := g1 | g2;
 
 	gS: key = generateSecret(keySpec);
 	tK: key = translateKey(otherKey);
-	Gens := gS | tK;
+	Gen := gS | tK;
 
 ORDER
-	Gets, Gens
+	Get, Gen
 
 CONSTRAINTS
-	keyFactoryAlgorithm in {"AES", "PBKDF2", "PBKDF2WithHmacSHA256", "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512",
+	algorithm in {"AES", "PBKDF2", "PBKDF2WithHmacSHA256", "PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512",
 				"PBKDF2WITHHMACSHA3-256", "PBKDF2WITHHMACSHA3-384", "PBKDF2WITHHMACSHA3-512",
 				"PBEWithSHA256And192BitAES-CBC-BC", "PBEWithSHA256And256BitAES-CBC-BC", "Camellia", 
 				"PBEwithSHAandTwofish-CBC"};
@@ -28,5 +28,4 @@ REQUIRES
 	speccedKey[keySpec, _];
 	
 ENSURES
-	generatedKey[key, keyFactoryAlgorithm];
-    
+	generatedKey[key, algorithm];

--- a/BouncyCastle-JCA/src/SecretKeySpec.crysl
+++ b/BouncyCastle-JCA/src/SecretKeySpec.crysl
@@ -4,19 +4,20 @@ OBJECTS
 	java.lang.String keyAlgorithm;
 	byte[] keyMaterial;
 	int len;
-	int off;
+	int offset;
 		
 EVENTS
 	c1: SecretKeySpec(keyMaterial, keyAlgorithm);
-	c2: SecretKeySpec(keyMaterial, off, len, keyAlgorithm);
-	Cons := c1 | c2;
+	c2: SecretKeySpec(keyMaterial, offset, len, keyAlgorithm);
+	Con := c1 | c2;
 	
 ORDER
-	Cons
+	Con
  	
 CONSTRAINTS
-	keyAlgorithm in {"AES", "HmacSHA224", "HmacSHA256", "HmacSHA384", "HmacSHA512"};
-	length[keyMaterial] >= off + len;
+	keyAlgorithm in {"AES", "HmacSHA224", "HmacSHA256", "HmacSHA384", "HmacSHA512",
+					"HMACSHA3-224", "HMACSHA3-256", "HMACSHA3-384", "HMACSHA3-512"};
+	length[keyMaterial] >= offset + len;
 	neverTypeOf[keyMaterial, java.lang.String];
 	
 REQUIRES

--- a/BouncyCastle-JCA/src/SecureRandom.crysl
+++ b/BouncyCastle-JCA/src/SecureRandom.crysl
@@ -3,40 +3,43 @@ SPEC java.security.SecureRandom
 OBJECTS 
 	byte[] seed;
 	byte[] genSeed;
-	java.lang.String randomAlgorithm;
+	java.lang.String algorithm;
 	long lSeed;
-	byte[] next;
+	byte[] bytes;
 	int randInt;
-
+	int randIntInRange;
+	int range;
+	
 EVENTS
 	c1: SecureRandom();
 	c2: SecureRandom(seed);
-	Cons := c1 | c2;
+	Con := c1 | c2;
 	
-	g1: getInstance(randomAlgorithm);
-	g2: getInstance(randomAlgorithm, _);
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
 	gI: getInstanceStrong();
-	Gets := g1 | g2 | gI;
+	Get := g1 | g2 | gI;
 	
-	Ins := Gets | Cons;
-
-	gS: genSeed = generateSeed(_);	
+	Ins := Get | Con;
 
 	s1: setSeed(seed);
 	s2: setSeed(lSeed);
-	Seeds := s1 | s2;
-	
-	nB: nextBytes(next);
+	Seed := s1 | s2;
+
+	gS: genSeed = generateSeed(_);	
+
+	nB: nextBytes(bytes);
 	nI: randInt = nextInt();
-	Nexts := nB | nI;
+	nIR: randIntInRange = nextInt(range);
+	Next := nB | nI | nIR;
 	
-	Ends := gS | Nexts;
+	End := gS | Next;
 
 ORDER
-	Ins, (Seeds?, Ends*)*
+	Ins, (Seed?, End*)*
  	
 CONSTRAINTS
-	randomAlgorithm in {"DEFAULT", "NONCEANDIV"};
+	algorithm in {"DEFAULT", "NONCEANDIV"};
 	
 REQUIRES	
 	randomized[seed];
@@ -45,6 +48,7 @@ REQUIRES
 ENSURES
 	randomized[this] after Ins;
 	randomized[genSeed] after gS;
-	randomized[next] after nB;
+	randomized[bytes] after nB;
 	randomized[randInt] after nI;
+	randomized[randIntInRange] after nIR;
 	

--- a/BouncyCastle-JCA/src/Signature.crysl
+++ b/BouncyCastle-JCA/src/Signature.crysl
@@ -2,13 +2,13 @@ SPEC java.security.Signature
 
 OBJECTS
 	byte[] sign;
-	byte inpb;
-	byte[] inpba;
-	byte[] out;
-	java.nio.ByteBuffer inpBuf;
-	java.lang.String signAlgorithm;
-	java.security.PrivateKey priv;
-	java.security.PublicKey pub;
+	byte inputByte;
+	byte[] input;
+	byte[] output;
+	java.nio.ByteBuffer inputByteBuffer;
+	java.lang.String algorithm;
+	java.security.PrivateKey privateKey;
+	java.security.PublicKey publicKey;
 	java.security.cert.Certificate cert;
 	java.security.spec.AlgorithmParameterSpec params;
 	boolean verified;
@@ -16,47 +16,47 @@ OBJECTS
 	int len;
 
 EVENTS
-	g1: getInstance(signAlgorithm);
-	g2: getInstance(signAlgorithm, _);
-	Gets := g1 | g2;
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
+	Get := g1 | g2;
 
-	i1: initSign(priv);
-	i2: initSign(priv, _);
+	i1: initSign(privateKey);
+	i2: initSign(privateKey, _);
 	i3: initVerify(cert);
-	i4: initVerify(pub);
-	InitSigns := i1 | i2;
-	InitVerifies := i3 | i4;
+	i4: initVerify(publicKey);
+	InitSign := i1 | i2;
+	InitVerify := i3 | i4;
 
-	u1: update(inpb);
-	u2: update(inpba);
-	u3: update(inpba, offset, len);
-	u4: update(inpBuf);
-	Updates := u1 | u2 | u3 | u4;
+	u1: update(input);
+	u2: update(inputByte);
+	u3: update(input, offset, len);
+	u4: update(inputByteBuffer);
+	Update := u1 | u2 | u3 | u4;
 
-	s1: out = sign();
-	s2: sign(out, offset, len);
-	Signs := s1 | s2;
+	s1: output = sign();
+	s2: sign(output, offset, len);
+	Sign := s1 | s2;
 
 	v1: verified = verify(sign);
 	v2: verified = verify(sign, offset, len);
-	Verifies := v1 | v2;
+	Verify := v1 | v2;
 
 ORDER
-	Gets, ((InitSigns+, (Updates+, Signs+)+ )+ | (InitVerifies+, (Updates*, Verifies+)+ )+ )
+	Get, ((InitSign+, (Update+, Sign+)+ )+ | (InitVerify+, (Update*, Verify+)+ )+ )
 
 CONSTRAINTS
-	signAlgorithm in {"ECDDSA", "SHA256WITHECDDSA", "SHA384WITHECDDSA", "SHA512WITHECDDSA", "SHA3-256WITHECDDSA", "SHA3-384WITHECDDSA", 
+	algorithm in {"ECDDSA", "SHA256WITHECDDSA", "SHA384WITHECDDSA", "SHA512WITHECDDSA", "SHA3-256WITHECDDSA", "SHA3-384WITHECDDSA", 
 			"SHA3-512WITHECDDSA", "SHA256WITHECNR", "SHA384WITHECNR", "SHA512WITHECNR", "SHA256withECDSA", "SHA256withDSA", 
 			"SHA224withRSA", "SHA384withRSA", "SHA512withRSA", "SHA256withRSA", "SHA224withDSA", "SHA384withDSA", "SHA512withDSA", 
 			"QTESLA"};
     
 REQUIRES
-	generatedPrivkey[priv];
-	generatedPubkey[pub];
+	generatedPrivkey[privateKey];
+	generatedPubkey[publicKey];
 
 ENSURES
-	signed[out, inpb] after Signs;
-	signed[out, inpba] after Signs;
-	signed[out, inpBuf] after Signs;
-	verified[verified, sign] after Verifies;
+	signed[output, inputByte] after Sign;
+	signed[output, input] after Sign;
+	signed[output, inputByteBuffer] after Sign;
+	verified[verified, sign] after Verify;
     

--- a/BouncyCastle-JCA/src/TrustAnchor.crysl
+++ b/BouncyCastle-JCA/src/TrustAnchor.crysl
@@ -1,21 +1,21 @@
 SPEC java.security.cert.TrustAnchor
 
 OBJECTS
-	java.security.PublicKey pubKey;
-	java.security.cert.X509Certificate cert;
-	javax.security.auth.x500.X500Principal princ;
+	java.security.PublicKey publicKey;
+	java.security.cert.X509Certificate trustedCert;
+	javax.security.auth.x500.X500Principal caPrincipal;
 	
 EVENTS
-	c1: TrustAnchor(_, pubKey, _);
-	c2: TrustAnchor(cert, _);
-	c3: TrustAnchor(princ, pubKey, _);
-	Cons := c1 | c2 | c3;
+	c1: TrustAnchor(_, publicKey, _);
+	c2: TrustAnchor(trustedCert, _);
+	c3: TrustAnchor(caPrincipal, publicKey, _);
+	Con := c1 | c2 | c3;
 	
 ORDER
-	Cons
+	Con
 	
 REQUIRES
-	generatedPubkey[pubKey];
+	generatedPubkey[publicKey];
 	
 ENSURES
 	generatedTrustAnchor[this];

--- a/BouncyCastle-JCA/src/TrustManagerFactory.crysl
+++ b/BouncyCastle-JCA/src/TrustManagerFactory.crysl
@@ -1,27 +1,28 @@
 SPEC javax.net.ssl.TrustManagerFactory
 
 OBJECTS
-	java.lang.String algo;
+	java.lang.String algorithm;
 	java.security.KeyStore keyStore;
 	javax.net.ssl.ManagerFactoryParameters params;
-	javax.net.ssl.TrustManager[] tms; 
+	javax.net.ssl.TrustManager[] trustManager; 
 	
 EVENTS
-	g1: getInstance(algo);
-	g2: getInstance(algo, _);
-	Gets := g1 | g2;
+	g1: getInstance(algorithm);
+	g2: getInstance(algorithm, _);
+	Get := g1 | g2;
 	
 	i1: init(keyStore);
 	i2: init(params);
 	Init := i1 | i2;
 	
-	GetTrustMng: tms = getTrustManagers();
+	gtm1: trustManager = getTrustManagers();
+	GetTrustMng := gtm1;
 	
 ORDER
-	Gets, Init, GetTrustMng?
+	Get, Init, GetTrustMng?
 	
 CONSTRAINTS
-	algo in {"PKIX", "X509", "X.509"};
+	algorithm in {"PKIX", "X509", "X.509"};
 
 REQUIRES
 	generatedKeyStore[keyStore];
@@ -29,4 +30,4 @@ REQUIRES
 															
 ENSURES
 	generatedTrustManager[this] after Init;			
-	generatedTrustManagers[tms] after GetTrustMng;
+	generatedTrustManagers[trustManager] after GetTrustMng;

--- a/BouncyCastle-JCA/src/X509EncodedKeySpec.crysl
+++ b/BouncyCastle-JCA/src/X509EncodedKeySpec.crysl
@@ -1,0 +1,17 @@
+SPEC java.security.spec.X509EncodedKeySpec
+
+OBJECTS 	
+	byte[] encodedKey;
+
+EVENTS
+	c1: X509EncodedKeySpec(encodedKey);
+	Con := c1;
+	
+ORDER
+	Con
+
+REQUIRES
+	preparedKeyMaterial[encodedKey];
+ 	
+ENSURES
+	speccedKey[this, _] after Con;


### PR DESCRIPTION
This PR refactors the BouncyCastle-JavaCryptographicArchitecture ruleset.

The changes include:

- Renaming of methods and variables. (Variable names are mostly updated to match the JavaDoc variable name)
- EVENTS are refactored to be consistent across all rules. ( All methods belong to an aggregate now)
- Small fixes in rules(See single commits)
- Added rules from JCA and vice versa

**Changes are to be tested in CryptoAnalysis**