### PR TITLE
Add PasswordAuthentication

### DIFF
--- a/BouncyCastle-JCA/src/PasswordAuthentication.crysl
+++ b/BouncyCastle-JCA/src/PasswordAuthentication.crysl
@@ -1,0 +1,26 @@
+SPEC java.net.PasswordAuthentication
+
+OBJECTS
+	java.lang.String userName;
+	java.lang.String retUserName;
+	char[] password;
+
+EVENTS
+	c1: PasswordAuthentication(userName, password);
+	Con := c1;
+
+	gp1: getPassword();
+	GetPassword := gp1;
+	
+	gu1: retUserName = getUserName();
+	GetUserName := gu1;
+	
+ORDER
+	Con, (GetPassword | GetUserName)*
+
+CONSTRAINTS
+	neverTypeOf[password, java.lang.String];
+	notHardCoded[password];
+	
+ENSURES
+	generatedPasswordAuthentication[this];

--- a/JavaCryptographicArchitecture/src/PasswordAuthentication.crysl
+++ b/JavaCryptographicArchitecture/src/PasswordAuthentication.crysl
@@ -1,0 +1,26 @@
+SPEC java.net.PasswordAuthentication
+
+OBJECTS
+	java.lang.String userName;
+	java.lang.String retUserName;
+	char[] password;
+
+EVENTS
+	c1: PasswordAuthentication(userName, password);
+	Con := c1;
+
+	gp1: getPassword();
+	GetPassword := gp1;
+	
+	gu1: retUserName = getUserName();
+	GetUserName := gu1;
+	
+ORDER
+	Con, (GetPassword | GetUserName)*
+
+CONSTRAINTS
+	neverTypeOf[password, java.lang.String];
+	notHardCoded[password];
+	
+ENSURES
+	generatedPasswordAuthentication[this];


### PR DESCRIPTION
This PR resolves #6 and adds a crysl rule for the PasswordAuthentication class to the bc-jca and jca ruleset.