### PR TITLE
Fix Order

### DIFF
--- a/BouncyCastle-JCA/src/Mac.crysl
+++ b/BouncyCastle-JCA/src/Mac.crysl
@@ -33,8 +33,9 @@ EVENTS
 	f1: output1 = doFinal();
 	f2: output2 = doFinal(input);
 	f3: doFinal(output1, outOffset);
-	FinalWU := f1 | f3;
-	Final := FinalWU | f2;
+	FinalWU := f2;
+	FinalWOU := f1 | f3;
+	Final := FinalWU | FinalWOU;
 
 ORDER
 	Get, Init, (FinalWU | (Update+, Final))

--- a/JavaCryptographicArchitecture/src/Mac.crysl
+++ b/JavaCryptographicArchitecture/src/Mac.crysl
@@ -33,9 +33,10 @@ EVENTS
 	f1: output1 = doFinal();
 	f2: output2 = doFinal(input);
 	f3: doFinal(output1, outOffset);
-	FinalWU := f1 | f3;
-	Final := FinalWU | f2;
-
+	FinalWU := f2;
+	FinalWOU := f1 | f3;
+	Final := FinalWU | FinalWOU;
+	
 ORDER
 	Get, Init, (FinalWU | (Update+, Final))
 


### PR DESCRIPTION
This PR fixes #105.
f2 = FinalWU can be with called without an explicit updates call due to its [implementation](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/javax/crypto/Mac.java#l616).

f1, f3 have to be called with an explicit updates call due to their [implementation](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/javax/crypto/Mac.java#l541).