### PR TITLE
Integrate public and private key

### DIFF
--- a/BouncyCastle-JCA/src/KeyAgreement.crysl
+++ b/BouncyCastle-JCA/src/KeyAgreement.crysl
@@ -2,10 +2,13 @@ SPEC javax.crypto.KeyAgreement
 
 OBJECTS
 	java.lang.String algorithm;
-	java.security.Key key;
+	java.lang.String symmetricKeyAlgorithm;
+	java.security.Key pubKey;
+	java.security.Key privKey;
+	javax.crypto.SecretKey sharedKey;
 	boolean lastPhase;
-	byte[] sharedSecret;
-	int off;
+	byte[] sharedSecretBuffer;
+	int offset;
 	java.security.spec.AlgorithmParameterSpec params;
 	java.security.SecureRandom random;
 	
@@ -14,28 +17,37 @@ EVENTS
 	g2: getInstance(algorithm, _);
 	Get := g1 | g2;
     
-	i1: init(key);
-	i2: init(key, params);
-	i3: init(key, params, random);
-	i4: init(key, random);
+	i1: init(privKey);
+	i2: init(privKey, params);
+	i3: init(privKey, params, random);
+	i4: init(privKey, random);
 	Init := i1 | i2 | i3 | i4;
     
-	dp1: doPhase(key, lastPhase);
+	dp1: doPhase(pubKey, lastPhase);
 	DoPhase := dp1;
     
-	gs1: generateSecret();
-	gs2: generateSecret(sharedSecret, off);
-	gs3: generateSecret(algorithm);
-	GenSecret := gs1 | gs2 | gs3;
+	gs1: sharedSecretBuffer = generateSecret();
+	gs2: generateSecret(sharedSecretBuffer, offset);
+	GenSecretBuffer := gs1 | g2;
+	
+	gs3: sharedKey = generateSecret(symmetricKeyAlgorithm);
+	GenSecret := gs3;
     
 ORDER
-	Get, Init, DoPhase, GenSecret
+	Get, Init, DoPhase, (GenSecret | GenSecretBuffer)
 	
 CONSTRAINTS
 	algorithm in {"DH", "DiffieHellman", "NH" ,"ECDH", "ECDHC"};
+	symmetricKeyAlgorithm in {"AES", "HmacSHA256", "HmacSHA384", "HmacSHA512",
+			 "HMACSHA3-256", "HMACSHA3-384", "HMACSHA3-512"};
 	
 REQUIRES
 	randomized[random];
+	generatedPrivkey[privKey];
+	generatedPubkey[pubKey];
+	algorithm in {"DiffieHellman", "DH"} => preparedDH[params];
+	algorithm in {"ECDH", "ECDHC"} => preparedEC[params];
     
 ENSURES 
-	agreedKey[key, algorithm];
+	generatedKey[sharedKey, symmetricKeyAlgorithm] after GenSecret;
+	preparedKeyMaterial[sharedSecretBuffer] after GenSecretBuffer;

--- a/JavaCryptographicArchitecture/src/KeyAgreement.crysl
+++ b/JavaCryptographicArchitecture/src/KeyAgreement.crysl
@@ -2,9 +2,12 @@ SPEC javax.crypto.KeyAgreement
 
 OBJECTS
 	java.lang.String algorithm;
-	java.security.Key key;
+	java.lang.String symmetricKeyAlgorithm;
+	java.security.Key pubKey;
+	java.security.Key privKey;
+	javax.crypto.SecretKey sharedKey;
 	boolean lastPhase;
-	byte[] sharedSecret;
+	byte[] sharedSecretBuffer;
 	int offset;
 	java.security.spec.AlgorithmParameterSpec params;
 	java.security.SecureRandom random;
@@ -14,28 +17,35 @@ EVENTS
 	g2: getInstance(algorithm, _);
 	Get := g1 | g2;
     
-	i1: init(key);
-	i2: init(key, params);
-	i3: init(key, params, random);
-	i4: init(key, random);
+	i1: init(privKey);
+	i2: init(privKey, params);
+	i3: init(privKey, params, random);
+	i4: init(privKey, random);
 	Init := i1 | i2 | i3 | i4;
     
-	dp1: doPhase(key, lastPhase);
+	dp1: doPhase(pubKey, lastPhase);
 	DoPhase := dp1;
     
-	gs1: generateSecret();
-	gs2: generateSecret(sharedSecret, offset);
-	gs3: generateSecret(algorithm);
-	GenSecret := gs1 | gs2 | gs3;
+	gs1: sharedSecretBuffer = generateSecret();
+	gs2: generateSecret(sharedSecretBuffer, offset);
+	GenSecretBuffer := gs1 | g2;
+	
+	gs3: sharedKey = generateSecret(symmetricKeyAlgorithm);
+	GenSecret := gs3 | GenSecretBuffer;
     
 ORDER
-	Get, Init, DoPhase, GenSecret
+	Get, Init, DoPhase, GenSecretBuffer
 	
 CONSTRAINTS
 	algorithm in {"DH", "DiffieHellman", "ECDH"};
+	noCallTo[gs3];
 	
 REQUIRES
 	randomized[random];
+	generatedPrivkey[privKey];
+	generatedPubkey[pubKey];
+	algorithm in {"DiffieHellman", "DH"} => preparedDH[params];
+	algorithm in {"ECDH"} => preparedEC[params];
     
-ENSURES 
-	agreedKey[key, algorithm];
+ENSURES
+	preparedKeyMaterial[sharedSecretBuffer] after GenSecretBuffer;


### PR DESCRIPTION
This PR fixes #106. The KeyAgreement crysl rule is updated for both JCA and BC-JCA. The rules are different because Oracle removed the support of the generateSecret(String) method see [here](https://www.oracle.com/java/technologies/javase/8u161-relnotes.html#JDK-8185292). Therefore, a noCallTo constraint is added to the jca crysl rule. 

The Bouncycastle implementation seems to work as expected. After looking through the source code, [(KeyAgreement)](https://github.com/bcgit/bc-java/blob/bc3b92f1f0e78b82e2584c5fb4b226a13e7f8b3b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/dh/KeyAgreementSpi.java#L249) and ([BaseAgreement](https://github.com/bcgit/bc-java/blob/9f95e5c710732bd8c703299b9d5ca1eea6f1317c/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/util/BaseAgreementSpi.java#L280)) implement functionality to tackle the concerns mentioned in the link above.