### PR TITLE
Update to support 120 bits security recommendation from BSI

### DIFF
--- a/BouncyCastle-JCA/src/DSAGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/DSAGenParameterSpec.crysl
@@ -14,11 +14,8 @@ ORDER
 	Con
 	
 CONSTRAINTS
-	primePLen in {1024, 2048, 3072};
-	subPrimeQLen in {160, 224, 256};
-	
-	primePLen in {1024} => subPrimeQLen in {160};
-	primePLen in {2048} => subPrimeQLen in {224, 256};
+	primePLen in {3072}; //BSI TR-02102-1 page 53
+	subPrimeQLen in {256};
 	primePLen in {3072} => subPrimeQLen in {256};
 	
 ENSURES

--- a/BouncyCastle-JCA/src/KeyPairGenerator.crysl
+++ b/BouncyCastle-JCA/src/KeyPairGenerator.crysl
@@ -29,9 +29,9 @@ CONSTRAINTS
 			"ECIES", "ElGamal", "McElieceKobaraImai", "McEliecePointcheval", "McElieceFujisaki", 
 			"McEliece", "McEliece-CCA2", "NH", "QTESLA", "Rainbow", "SPHINCS256", "XMSS", "XMSSMT"};
 						
-	algorithm in {"RSA"} => keysize in {4096, 3072, 2048};
-	algorithm in {"DSA"} => keysize in {2048};
-	algorithm in {"DiffieHellman", "DH"} => keysize in {2048};
+	algorithm in {"RSA"} => keysize in {4096, 3072}; //BSI TR-02102-1 Recommends atleast 3000bits for keys
+	algorithm in {"DSA"} => keysize in {3072};
+	algorithm in {"DiffieHellman", "DH"} => keysize in {3072};
 	algorithm in {"EC", "ECDSA", "ECDH", "ECDHWITHSHA1KDF", "ECDHC", "ECIES"} => keysize in {256};
 	
 REQUIRES

--- a/BouncyCastle-JCA/src/RSAKeyGenParameterSpec.crysl
+++ b/BouncyCastle-JCA/src/RSAKeyGenParameterSpec.crysl
@@ -12,7 +12,7 @@ ORDER
 	Con
 	
 CONSTRAINTS
-	keysize in {1024, 2048, 4096};
+	keysize in {4096}; //BSI TR-02102-1 Recommends atleast 3000bits for keys
 	publicExponent in {65537};
 	 
 ENSURES

--- a/BouncyCastle/src/RSAKeyParameters.crysl
+++ b/BouncyCastle/src/RSAKeyParameters.crysl
@@ -13,7 +13,7 @@ ORDER
 	Con	
 	
 CONSTRAINTS
-	modulus >= 2000; // BSI describes length of the modulus n to be at least 2000 bits
+	modulus >= 3000; // BSI describes length of the modulus n to be at least 2000 bits
 	isPrivate == true => notHardCoded[exponent];
 
 ENSURES

--- a/BouncyCastle/src/RSAPrivateCrtKeyParameters.crysl
+++ b/BouncyCastle/src/RSAPrivateCrtKeyParameters.crysl
@@ -18,7 +18,7 @@ ORDER
 	Con
 	
 CONSTRAINTS
-	modulus >= 2000; // BSI describes length of the modulus n to be at least 2000 bits
+	modulus >= 3000; // BSI describes length of the modulus n to be at least 2000 bits
 	p != q;
 	
 REQUIRES

--- a/JavaCryptographicArchitecture/src/DSAGenParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/DSAGenParameterSpec.crysl
@@ -14,11 +14,9 @@ ORDER
 	Con
 	
 CONSTRAINTS
-	primePLen in {1024, 2048, 3072};
-	subPrimeQLen in {160, 224, 256};
-	
-	primePLen in {1024} => subPrimeQLen in {160};
-	primePLen in {2048} => subPrimeQLen in {224, 256};
+	primePLen in {3072}; //BSI TR-02102-1 page 53
+	subPrimeQLen in {256};
+
 	primePLen in {3072} => subPrimeQLen in {256};
 
 ENSURES

--- a/JavaCryptographicArchitecture/src/KeyPairGenerator.crysl
+++ b/JavaCryptographicArchitecture/src/KeyPairGenerator.crysl
@@ -25,10 +25,10 @@ ORDER
 	Get, Init, Gen
 
 CONSTRAINTS
-	algorithm in {"RSA", "EC", "DSA", "DiffieHellman", "DH"};
-	algorithm in {"RSA"} => keysize in {4096, 3072, 2048};
-	algorithm in {"DSA"} => keysize in {2048};
-	algorithm in {"DiffieHellman", "DH"} => keysize in {2048};
+	algorithm in {"RSA", "EC", "DSA", "DiffieHellman", "DH"}; //BSI TR-02102-1 Recommends atleast 3000bits for keys
+	algorithm in {"RSA"} => keysize in {4096, 3072};
+	algorithm in {"DSA"} => keysize in {3072};
+	algorithm in {"DiffieHellman", "DH"} => keysize in {3072};
 	algorithm in {"EC"} => keysize in {256};
 
 REQUIRES

--- a/JavaCryptographicArchitecture/src/RSAKeyGenParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/RSAKeyGenParameterSpec.crysl
@@ -12,7 +12,7 @@ ORDER
 	Con
 	
 CONSTRAINTS
-	keysize in {1024, 2048, 4096};
+	keysize in {3072, 4096}; //BSI TR-02102-1 Recommends atleast 3000bits for keys
 	publicExponent in {65537};
 	 
 ENSURES


### PR DESCRIPTION
This PR updates the related CrySL rules to align with the recommendation from [BSI (2023)](https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf?__blob=publicationFile&v=8) for cryptographic key lengths.