### PR TITLE
Add rules for PrivateKey and PublicKey

### DIFF
--- a/BouncyCastle-JCA/src/PrivateKey.crysl
+++ b/BouncyCastle-JCA/src/PrivateKey.crysl
@@ -1,0 +1,14 @@
+SPEC java.security.PrivateKey
+
+OBJECTS 
+	byte[] keyMaterial;
+
+EVENTS
+	ge1: keyMaterial = getEncoded();
+	GetEnc := ge1;
+
+ORDER
+	GetEnc*
+	
+ENSURES
+	preparedKeyMaterial[keyMaterial] after GetEnc;

--- a/BouncyCastle-JCA/src/PublicKey.crysl
+++ b/BouncyCastle-JCA/src/PublicKey.crysl
@@ -1,0 +1,14 @@
+SPEC java.security.PublicKey
+
+OBJECTS 
+	byte[] keyMaterial;
+
+EVENTS
+	ge1: keyMaterial = getEncoded();
+	GetEnc := ge1;
+
+ORDER
+	GetEnc*
+	
+ENSURES
+	preparedKeyMaterial[keyMaterial] after GetEnc;

--- a/BouncyCastle/src/AESEngine.crysl
+++ b/BouncyCastle/src/AESEngine.crysl
@@ -1,10 +1,10 @@
 SPEC org.bouncycastle.crypto.engines.AESEngine
 
-OBJECTS
-	int dummy; //This section can't be empty or else the rule is marked with an error.
+FORBIDDEN
+	AESEngine();
 
 EVENTS
-	c1: AESEngine();
+	c1: newInstance();
 	Con := c1;
 	
 ORDER

--- a/BouncyCastle/src/AESFastEngine.crysl
+++ b/BouncyCastle/src/AESFastEngine.crysl
@@ -1,17 +1,5 @@
 //The AESFastEngine class is deprecated and insecure. This crysl rule ensures that a AESFastEngine object is considered insecure.
 SPEC org.bouncycastle.crypto.engines.AESFastEngine
-
-OBJECTS
-	int dummy; //This section can't be empty or else the rule is marked with an error.
 	
 FORBIDDEN
-	AESFastEngine() ;
-
-EVENTS	
-	c1: AESFastEngine();
-	Con := c1;
-	
-ORDER
-	Con
-
-
+	AESFastEngine();

--- a/BouncyCastle/src/AESLightEngine.crysl
+++ b/BouncyCastle/src/AESLightEngine.crysl
@@ -1,8 +1,5 @@
 SPEC org.bouncycastle.crypto.engines.AESLightEngine
 
-OBJECTS
-	int dummy; //This section can't be empty or else the rule is marked with an error.
-
 EVENTS	
 	c1: AESLightEngine();
 	Con := c1;

--- a/BouncyCastle/src/BufferedBlockCipher.crysl
+++ b/BouncyCastle/src/BufferedBlockCipher.crysl
@@ -1,49 +1,5 @@
+// Deprecated
 SPEC org.bouncycastle.crypto.BufferedBlockCipher
 
-OBJECTS
-	org.bouncycastle.crypto.BlockCipher cipher;
-	org.bouncycastle.crypto.CipherParameters params;
-	
-	byte plainTextByte;
-	byte[] plainText;
-	int plainTextOffset;
-	int plainTextLen;
-	
-	byte[] cipherText;
-	int cipherTextOffset;
-	
-	boolean isEncryption;
-
-	
-EVENTS
-	c1: BufferedBlockCipher(cipher);
-	Con := c1;
-
-	i1: init(isEncryption, params);
-	Init := i1;
-
-//	@return the number of output bytes copied to out.
-	p1: processByte(plainTextByte, cipherText, cipherTextOffset);
-	p2: processBytes(plainText, plainTextOffset, plainTextLen, cipherText, cipherTextOffset);
-	Proc := p1 | p2;
-	
-//	@return the number of output bytes copied to out.
-	df1: doFinal(cipherText, cipherTextOffset);
-	DoFinal := df1;
-	
-ORDER
-	Con, (Init, Proc, DoFinal)+
-	
-CONSTRAINTS
-	length[plainText] >= plainTextOffset + plainTextLen;
-	length[cipherText] >= cipherTextOffset;
-	plainTextOffset >= 0;
-	plainTextLen > 0;
-	cipherTextOffset >= 0;
-	
-REQUIRES
-	generatedGCMBlockCipher[cipher];
-	generatedCipherParams[params];
-	
-ENSURES
-	encrypted[cipherText];
+FORBIDDEN
+	BufferedBlockCipher(org.bouncycastle.crypto.BlockCipher);

--- a/BouncyCastle/src/CBCBlockCipher.crysl
+++ b/BouncyCastle/src/CBCBlockCipher.crysl
@@ -2,12 +2,15 @@ SPEC org.bouncycastle.crypto.modes.CBCBlockCipher
 
 OBJECTS
 	org.bouncycastle.crypto.BlockCipher engine;
+
+FORBIDDEN
+	CBCBlockCipher(org.bouncycastle.crypto.BlockCipher);
 	
 EVENTS
-	c1: CBCBlockCipher(engine);
+	c1: newInstance(engine);
 	Con := c1;
 
-//No need to specify the order, must be wrapped in PaddedBufferedCipher!
+// No need to specify the order, must be wrapped in PaddedBufferedCipher!
 ORDER
 	Con
 	

--- a/BouncyCastle/src/DefaultBufferedBlockCipher.crysl
+++ b/BouncyCastle/src/DefaultBufferedBlockCipher.crysl
@@ -1,13 +1,8 @@
-SPEC org.bouncycastle.crypto.modes.CCMBlockCipher
+SPEC org.bouncycastle.crypto.DefaultBufferedBlockCipher
 
 OBJECTS
-	org.bouncycastle.crypto.BlockCipher engine;
+	org.bouncycastle.crypto.BlockCipher cipher;
 	org.bouncycastle.crypto.CipherParameters params;
-	
-	byte aadByte;
-	byte[] aadBytes;
-	int aadOff;
-	int aadLen;
 	
 	byte plainTextByte;
 	byte[] plainText;
@@ -18,38 +13,36 @@ OBJECTS
 	int cipherTextOffset;
 	
 	boolean isEncryption;
-
-FORBIDDEN
-	CCMBlockCipher(org.bouncycastle.crypto.BlockCipher);
 	
 EVENTS
-	c1: newInstance(engine);
+	c1: DefaultBufferedBlockCipher(cipher);
 	Con := c1;
-	
+
 	i1: init(isEncryption, params);
 	Init := i1;
-	
-	pa1: processAADByte(aadByte);
-	pa2: processAADBytes(aadBytes, aadOff, aadLen);
-	ProcessAAD := pa1 | pa2;
-	
+
+//	@return the number of output bytes copied to out.
 	p1: processByte(plainTextByte, cipherText, cipherTextOffset);
 	p2: processBytes(plainText, plainTextOffset, plainTextLen, cipherText, cipherTextOffset);
-	Process := p1 | p2;
+	Proc := p1 | p2;
 	
+//	@return the number of output bytes copied to out.
 	df1: doFinal(cipherText, cipherTextOffset);
 	DoFinal := df1;
-
+	
 ORDER
-	Con, Init, ProcessAAD*, Process+, DoFinal
+	Con, (Init, Proc, DoFinal)+
 	
 CONSTRAINTS
-	length[cipherText] >= cipherTextOffset;
 	length[plainText] >= plainTextOffset + plainTextLen;
+	length[cipherText] >= cipherTextOffset;
 	plainTextOffset >= 0;
 	plainTextLen > 0;
 	cipherTextOffset >= 0;
-
+	
 REQUIRES
-	generatedAESEngine[engine] || generatedAESLightEngine[engine] || generatedRijndaelEngine[engine];
-	generatedAEADParameters[params] || generatedParametersWithIV[params];
+	generatedGCMBlockCipher[cipher];
+	generatedCipherParams[params];
+	
+ENSURES
+	encrypted[cipherText];

--- a/BouncyCastle/src/GCMBlockCipher.crysl
+++ b/BouncyCastle/src/GCMBlockCipher.crysl
@@ -18,9 +18,12 @@ OBJECTS
 	int cipherTextOffset;
 	
 	boolean isEncryption;
+
+FORBIDDEN
+	GCMBlockCipher(org.bouncycastle.crypto.BlockCipher);
 	
 EVENTS
-	c1: GCMBlockCipher(engine);
+	c1: newInstance(engine);
 	Con := c1;
 	
 	i1: init(isEncryption, params);

--- a/BouncyCastle/src/SHA256Digest.crysl
+++ b/BouncyCastle/src/SHA256Digest.crysl
@@ -37,7 +37,7 @@ CONSTRAINTS
 	inputBytesOffset >= 0;
 	inputBytesLen > 0;
 	length[outputBytes] >= outputBytesOffset;
-	outputBytesOffset > 0;
+	outputBytesOffset >= 0;
 	
 REQUIRES
 	generatedSHA256Digest[digest];

--- a/BouncyCastle/src/SICBlockCipher.crysl
+++ b/BouncyCastle/src/SICBlockCipher.crysl
@@ -1,15 +1,16 @@
 SPEC org.bouncycastle.crypto.modes.SICBlockCipher
 
 OBJECTS
-
 	org.bouncycastle.crypto.BlockCipher engine;
+
+FORBIDDEN
+	SICBlockCipher(org.bouncycastle.crypto.BlockCipher);
 	
 EVENTS
-	c1: SICBlockCipher(engine);
+	c1: newInstance(engine);
 	Con := c1;
 	
-//No need to specify the order, must be wrapped in BufferedCipher
-	
+// No need to specify the order, must be wrapped in BufferedCipher
 ORDER
 	Con
 

--- a/JavaCryptographicArchitecture/src/PrivateKey.crysl
+++ b/JavaCryptographicArchitecture/src/PrivateKey.crysl
@@ -1,0 +1,14 @@
+SPEC java.security.PrivateKey
+
+OBJECTS 
+	byte[] keyMaterial;
+
+EVENTS
+	ge1: keyMaterial = getEncoded();
+	GetEnc := ge1;
+
+ORDER
+	GetEnc*
+	
+ENSURES
+	preparedKeyMaterial[keyMaterial] after GetEnc;

--- a/JavaCryptographicArchitecture/src/PublicKey.crysl
+++ b/JavaCryptographicArchitecture/src/PublicKey.crysl
@@ -1,0 +1,14 @@
+SPEC java.security.PublicKey
+
+OBJECTS 
+	byte[] keyMaterial;
+
+EVENTS
+	ge1: keyMaterial = getEncoded();
+	GetEnc := ge1;
+
+ORDER
+	GetEnc*
+	
+ENSURES
+	preparedKeyMaterial[keyMaterial] after GetEnc;


### PR DESCRIPTION
Add rules for the classes `java.security.PublicKey` and `java.security.PrivateKey` and update BouncyCastle to disable deprecated APIs