### PR TITLE
Required predicates with this

### DIFF
--- a/BouncyCastle-JCA/pom.xml
+++ b/BouncyCastle-JCA/pom.xml
@@ -6,7 +6,6 @@
 	<artifactId>BouncyCastle-JCA</artifactId>
 	<version>3.0.2</version>
 	<name>CrySL Rules Bundle</name>
-
 	<licenses>
 		<license>
 			<name>Eclipse Public License - v2.0</name>

--- a/BouncyCastle-JCA/src/Key.crysl
+++ b/BouncyCastle-JCA/src/Key.crysl
@@ -2,14 +2,16 @@ SPEC java.security.Key
 
 OBJECTS 
 	byte[] keyMaterial;
-	
+
 EVENTS
 	ge1: keyMaterial = getEncoded();
 	GetEnc := ge1;
-	
+
 ORDER
 	GetEnc*
+
+REQUIRES
+	generatedKey[this, _] || generatedPubkey[this] || generatedPrivkey[this];
 	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;
-	

--- a/BouncyCastle-JCA/src/KeyPair.crysl
+++ b/BouncyCastle-JCA/src/KeyPair.crysl
@@ -22,6 +22,7 @@ ORDER
 REQUIRES
 	generatedPrivkey[privateKey];
 	generatedPubkey[publicKey];
+	noCallTo[Con] => generatedKeypair[this, _];
 	
 ENSURES
 	generatedKeypair[this, _] after Con;

--- a/BouncyCastle-JCA/src/PrivateKey.crysl
+++ b/BouncyCastle-JCA/src/PrivateKey.crysl
@@ -9,6 +9,9 @@ EVENTS
 
 ORDER
 	GetEnc*
+
+REQUIRES
+	generatedPrivkey[this];
 	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;

--- a/BouncyCastle-JCA/src/PublicKey.crysl
+++ b/BouncyCastle-JCA/src/PublicKey.crysl
@@ -9,6 +9,9 @@ EVENTS
 
 ORDER
 	GetEnc*
+
+REQUIRES
+	generatedPubkey[this];
 	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;

--- a/BouncyCastle-JCA/src/SecretKey.crysl
+++ b/BouncyCastle-JCA/src/SecretKey.crysl
@@ -12,11 +12,12 @@ EVENTS
 
 ORDER
 	GetEnc*, Destroy?
+
+REQUIRES
+	generatedKey[this, _];
 			
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;
 
 NEGATES
 	generatedKey[this, _] after Destroy;
-
-	

--- a/JavaCryptographicArchitecture/pom.xml
+++ b/JavaCryptographicArchitecture/pom.xml
@@ -6,7 +6,6 @@
 	<artifactId>JavaCryptographicArchitecture</artifactId>
 	<version>3.0.2</version>
 	<name>CrySL Rules Bundle</name>
-
 	<licenses>
 		<license>
 			<name>Eclipse Public License - v2.0</name>

--- a/JavaCryptographicArchitecture/src/Key.crysl
+++ b/JavaCryptographicArchitecture/src/Key.crysl
@@ -9,6 +9,9 @@ EVENTS
 
 ORDER
 	GetEnc*
+
+REQUIRES
+	generatedKey[this, _] || generatedPubkey[this] || generatedPrivkey[this];
 	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;

--- a/JavaCryptographicArchitecture/src/KeyPair.crysl
+++ b/JavaCryptographicArchitecture/src/KeyPair.crysl
@@ -22,6 +22,7 @@ ORDER
 REQUIRES
 	generatedPrivkey[privateKey];
 	generatedPubkey[publicKey];
+	noCallTo[Con] => generatedKeypair[this, _];
 	
 ENSURES
 	generatedKeypair[this, _] after Con;

--- a/JavaCryptographicArchitecture/src/PrivateKey.crysl
+++ b/JavaCryptographicArchitecture/src/PrivateKey.crysl
@@ -9,6 +9,9 @@ EVENTS
 
 ORDER
 	GetEnc*
+
+REQUIRES
+	generatedPrivkey[this];
 	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;

--- a/JavaCryptographicArchitecture/src/PublicKey.crysl
+++ b/JavaCryptographicArchitecture/src/PublicKey.crysl
@@ -9,6 +9,9 @@ EVENTS
 
 ORDER
 	GetEnc*
+
+REQUIRES
+	generatedPubkey[this];
 	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;

--- a/JavaCryptographicArchitecture/src/SecretKey.crysl
+++ b/JavaCryptographicArchitecture/src/SecretKey.crysl
@@ -12,6 +12,9 @@ EVENTS
 
 ORDER
 	GetEnc*, Destroy?
+
+REQUIRES
+	generatedKey[this, _];
 			
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;


### PR DESCRIPTION
Since CryptoAnalysis 3.1.0, rules can have required predicates with the keyword `this` as parameter to ensure that objects, that are created by a different seed (e.g. `SecretKey` is generated by `KeyGenerator`), are created securely.