### PR TITLE
Tink update

### DIFF
--- a/Tink/src/DeterministicAeadKeyTemplates.crysl
+++ b/Tink/src/DeterministicAeadKeyTemplates.crysl
@@ -33,4 +33,3 @@ CONSTRAINTS
 	
 ENSURES
 	keyTemplate[aes256_siv];
-	

--- a/Tink/src/DeterministicAeadKeyTemplates.crysl
+++ b/Tink/src/DeterministicAeadKeyTemplates.crysl
@@ -1,19 +1,3 @@
-/*
- * This is a CrySL specification for the Google Tink implementation of 
- * the class DeterministicAeadKeyTemplates. 
- * 
- * Note: in this case, we are not specifying the correct usage of the 
- * API, but actually guaranteeing that the Google Tink API implementation 
- * actually exposes some key templates as static attributes. This 
- * information simplifies the specification of other properties for 
- * correctly using the API. 
- * 
- * 
- * It constraints the use of the API to the following key templates: 
- * 
- * - aes256_siv
- */
-
 SPEC com.google.crypto.tink.daead.DeterministicAeadKeyTemplates
 
 OBJECTS

--- a/Tink/src/DeterministicAeadKeyTemplates.crysl
+++ b/Tink/src/DeterministicAeadKeyTemplates.crysl
@@ -1,3 +1,20 @@
+/*
+ * This is a CrySL specification for the Google Tink implementation of 
+ * the class DeterministicAeadKeyTemplates. 
+ * 
+ * Note: in this case, we are not specifying the correct usage of the 
+ * API, but actually guaranteeing that the Google Tink API implementation 
+ * actually exposes some key templates as static attributes. This 
+ * information simplifies the specification of other properties for 
+ * correctly using the API. 
+ * 
+ * 
+ * It constraints the use of the API to the following key templates: 
+ * 
+ * - aes256_siv
+ */
+
+
 SPEC com.google.crypto.tink.daead.DeterministicAeadKeyTemplates
 
 OBJECTS

--- a/Tink/src/KeyTemplate.crysl
+++ b/Tink/src/KeyTemplate.crysl
@@ -1,14 +1,12 @@
-/*
- * A CrySL specification for using the AEAD Factory 
- * of the Google Google library. 
- */
-SPEC com.google.crypto.tink.proto.KeyTemplate
+SPEC com.google.crypto.tink.KeyTemplate
 
 OBJECTS
-	int x; 	
+	com.google.crypto.tink.KeyTemplate template
+	com.google.crypto.tink.Parameters params
+		
 EVENTS
-	evt : newBuilder(); 
+	cre: template = createFrom(params)
 ORDER
-	evt*
+	cre+
 ENSURES
-	readyForInstantiating[this];
+	genKeyTemplate[template]

--- a/Tink/src/KeyTemplateOld.crysl
+++ b/Tink/src/KeyTemplateOld.crysl
@@ -1,0 +1,15 @@
+/*
+ * A CrySL specification for using the AEAD Factory 
+ * of the Google Google library. 
+ */
+SPEC com.google.crypto.tink.proto.KeyTemplate
+
+OBJECTS
+	int x; 	
+
+EVENTS
+	evt : newBuilder(); 
+ORDER
+	evt*
+ENSURES
+	readyForInstantiating[this];

--- a/Tink/src/KeysetHandle.crysl
+++ b/Tink/src/KeysetHandle.crysl
@@ -9,21 +9,27 @@
 SPEC com.google.crypto.tink.KeysetHandle
 
 OBJECTS
-    com.google.crypto.tink.proto.KeyTemplate kt;
+    com.google.crypto.tink.KeyTemplate kt;
     com.google.crypto.tink.KeysetHandle publicKeysetHandle; 
+    com.google.crypto.tink.mac.HmacParameters hmacParams;
+    
 
 EVENTS
     gen_evt        : generateNew(kt);
+    gen_hmac_evt   : generateNew(hmacParams);
     gen_public_evt : publicKeysetHandle = getPublicKeysetHandle();
     read_evt       : read(_, _); 
     export_evt     : write(_, _); 
+    get_prim       : getPrimitive(_);
     
 ORDER
-    (gen_evt | read_evt), gen_public_evt?, export_evt?  
+    (gen_evt | read_evt), gen_public_evt?, export_evt?, get_prim*
    
 
 REQUIRES
-	keyTemplate[kt];
+	genKeyTemplate[kt];
+	hmacParams[hmacParams];
+	
 	
 ENSURES
 	generatedKeySet[this];

--- a/Tink/src/PredefinedDeterministicAeadParameters.crysl
+++ b/Tink/src/PredefinedDeterministicAeadParameters.crysl
@@ -1,0 +1,14 @@
+SPEC com.google.crypto.tink.daead.PredefinedDeterministicAeadParameters
+
+OBJECTS
+	com.google.crypto.tink.daead.AesSivParameters params;
+	com.google.crypto.tink.daead.PredefinedDeterministicAeadParameters aeadParams;
+
+EVENTS
+	aead256: params = aeadParams.AES256_SIV;
+
+ORDER
+	con*
+
+ENSURES
+	genAeadParams[params];

--- a/Tink/src/PredefinedMacParameters.crysl
+++ b/Tink/src/PredefinedMacParameters.crysl
@@ -1,0 +1,19 @@
+SPEC com.google.crypto.tink.mac.PredefinedMacParameters 
+
+OBJECTS
+	com.google.crypto.tink.mac.HmacParameters hmacParams;
+	com.google.crypto.tink.mac.PredefinedMacParameters macParams
+	
+EVENTS
+	hmac_sha256_128 : hmac_sha256 = macParams.HMAC_SHA256_128BITTAG
+	hmac_sha256_256 : hmac_sha256 = macParams.HMAC_SHA256_256BITTAG
+	Hmac_sha256: hmac_sha256_128 | hmac_sha256_256
+	
+ORDER 
+	Hmac_sha256+
+
+CONSTRAINTS
+
+	
+ENSURES
+	hmacParams[hmacParams]

--- a/Tink/src/PredefinedMacParameters.crysl
+++ b/Tink/src/PredefinedMacParameters.crysl
@@ -11,9 +11,6 @@ EVENTS
 	
 ORDER 
 	Hmac_sha256+
-
-CONSTRAINTS
-
 	
 ENSURES
 	hmacParams[hmacParams]


### PR DESCRIPTION
Add deprecated KeyTemplate. KeySet Handle uses now the non deprecated version of KeyTemplate. If the old class is used a required predicate error will be shown.

PredefinedMacParameters is added as new KeySet handle requires this.