### PR TITLE
CWE mappings in CrySL rules

### DIFF
--- a/JavaCryptographicArchitecture/src/AlgorithmParameterGenerator.crysl
+++ b/JavaCryptographicArchitecture/src/AlgorithmParameterGenerator.crysl
@@ -34,3 +34,9 @@ REQUIRES
 
 ENSURES
 	preparedAlg[algParams, algorithm] after GenParam;
+
+WEAKNESSES
+    CWE-326;
+    CWE-327;
+    CWE-329;
+    CWE-330;

--- a/JavaCryptographicArchitecture/src/AlgorithmParameters.crysl
+++ b/JavaCryptographicArchitecture/src/AlgorithmParameters.crysl
@@ -42,3 +42,9 @@ REQUIRES
 ENSURES 
 	preparedAlg[this, algorithm] after Init;
 	preparedAlg[encParams, algorithm] after GetEncoded;
+	
+WEAKNESSES
+    CWE-325;
+    CWE-326;
+    CWE-330;
+    CWE-916;

--- a/JavaCryptographicArchitecture/src/CertPathTrustManagerParameters.crysl
+++ b/JavaCryptographicArchitecture/src/CertPathTrustManagerParameters.crysl
@@ -15,3 +15,8 @@ REQUIRES
 	
 ENSURES
 	generatedManagerFactoryParameters[this];
+
+WEAKNESSES
+    CWE-295;
+    CWE-330;
+	CWE-347;

--- a/JavaCryptographicArchitecture/src/CertificateFactory.crysl
+++ b/JavaCryptographicArchitecture/src/CertificateFactory.crysl
@@ -29,3 +29,8 @@ CONSTRAINTS
 	
 ENSURES
 	generatedCert[type];
+
+WEAKNESSES
+    CWE-295;
+    CWE-693;
+	CWE-347;

--- a/JavaCryptographicArchitecture/src/Cipher.crysl
+++ b/JavaCryptographicArchitecture/src/Cipher.crysl
@@ -78,6 +78,9 @@ EVENTS
 	wkb1: wrappedKeyBytes = wrap(wrappedKey);
 	WKB := wkb1;
     
+	iv1: getIV();
+	IV := iv1;
+    
 ORDER
 	Get, Init+, AADUpdate*, WKB+ | (FINWOU | (Update+, DoFinal))+
 
@@ -106,6 +109,8 @@ CONSTRAINTS
 	alg(transformation) in {"AES"} && mode(transformation) in {"GCM", "CTR", "CTS", "CFB", "OFB"} => pad(transformation) in {"NoPadding"};
 	
 	mode(transformation) in {"CTR", "CTS", "CFB", "OFB"} && encmode != 1 => noCallTo[IWOIV];
+	mode(transformation) in {"CTR", "CTS", "CFB", "OFB"} && encmode == 1 => callTo[IV];
+	
 	mode(transformation) in {"CTR", "CTS", "CFB", "ECB", "OFB"} => noCallTo[AADUpdate];
 	     
     
@@ -137,3 +142,12 @@ ENSURES
 	encrypted[cipherText, plainText];
 	encrypted[cipherTextByteBuffer, plainTextByteBuffer];
 	wrappedKey[wrappedKeyBytes, wrappedKey];
+
+WEAKNESSES
+    CWE-1240;
+    CWE-327;
+    CWE-329;
+    CWE-330;
+    CWE-335;
+    CWE-338;
+    CWE-780;

--- a/JavaCryptographicArchitecture/src/CipherInputStream.crysl
+++ b/JavaCryptographicArchitecture/src/CipherInputStream.crysl
@@ -32,3 +32,11 @@ REQUIRES
 	
 ENSURES
 	cipheredInputStream[inputStream, cipher];
+
+WEAKNESSES
+    CWE-20;
+    CWE-284;
+    CWE-326;
+    CWE-404;
+    CWE-617;
+    CWE-665;

--- a/JavaCryptographicArchitecture/src/CipherOutputStream.crysl
+++ b/JavaCryptographicArchitecture/src/CipherOutputStream.crysl
@@ -33,3 +33,8 @@ REQUIRES
 
 ENSURES
 	cipheredOutputStream[outputStream, cipher];
+
+WEAKNESSES
+	CWE-404;
+    CWE-665;
+    CWE-704;

--- a/JavaCryptographicArchitecture/src/Cookie.crysl
+++ b/JavaCryptographicArchitecture/src/Cookie.crysl
@@ -20,3 +20,6 @@ CONSTRAINTS
 
 ENSURES
 	generatedCookie[this];
+	
+WEAKNESSES
+    CWE-614;

--- a/JavaCryptographicArchitecture/src/DHGenParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/DHGenParameterSpec.crysl
@@ -16,3 +16,6 @@ CONSTRAINTS
 
 ENSURES
 	preparedDH[this];
+	
+WEAKNESSES
+    CWE-326;

--- a/JavaCryptographicArchitecture/src/DHParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/DHParameterSpec.crysl
@@ -19,3 +19,6 @@ CONSTRAINTS
 	
 ENSURES
 	preparedDH[this];
+	
+WEAKNESSES
+    CWE-326;

--- a/JavaCryptographicArchitecture/src/DSAGenParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/DSAGenParameterSpec.crysl
@@ -21,3 +21,7 @@ CONSTRAINTS
 
 ENSURES
 	preparedDSA[this];
+	
+WEAKNESSES
+    CWE-326;
+    CWE-327;

--- a/JavaCryptographicArchitecture/src/DSAParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/DSAParameterSpec.crysl
@@ -18,3 +18,6 @@ CONSTRAINTS
 	
 ENSURES
 	preparedDSA[this];
+	
+WEAKNESSES
+    CWE-326;

--- a/JavaCryptographicArchitecture/src/DigestInputStream.crysl
+++ b/JavaCryptographicArchitecture/src/DigestInputStream.crysl
@@ -34,3 +34,7 @@ REQUIRES
 
 ENSURES
 	digestedInputStream[stream, digest];
+
+WEAKNESSES
+	CWE-325;
+    CWE-665;

--- a/JavaCryptographicArchitecture/src/DigestOutputStream.crysl
+++ b/JavaCryptographicArchitecture/src/DigestOutputStream.crysl
@@ -35,3 +35,8 @@ REQUIRES
 	
 ENSURES
 	digestedOutputStream[stream, digest];
+
+WEAKNESSES
+    CWE-1284;
+    CWE-305;
+    CWE-345;

--- a/JavaCryptographicArchitecture/src/ECGenParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/ECGenParameterSpec.crysl
@@ -23,3 +23,7 @@ CONSTRAINTS
 
 ENSURES
 	preparedEC[this];
+
+WEAKNESSES
+    CWE-327;
+	CWE-326;

--- a/JavaCryptographicArchitecture/src/ECParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/ECParameterSpec.crysl
@@ -15,3 +15,8 @@ ORDER
 
 ENSURES
 	preparedEC[this];
+	
+WEAKNESSES
+    CWE-1240;
+    CWE-326;
+    CWE-327;

--- a/JavaCryptographicArchitecture/src/GCMParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/GCMParameterSpec.crysl
@@ -25,3 +25,7 @@ REQUIRES
 	
 ENSURES
 	preparedGCM[this];
+
+WEAKNESSES
+	CWE-323
+    CWE-330;

--- a/JavaCryptographicArchitecture/src/HMACParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/HMACParameterSpec.crysl
@@ -12,3 +12,9 @@ ORDER
 	
 ENSURES
 	preparedHMAC[this];
+	
+WEAKNESSES
+    CWE-325;
+    CWE-326;
+    CWE-327;
+    CWE-328;

--- a/JavaCryptographicArchitecture/src/IvParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/IvParameterSpec.crysl
@@ -23,3 +23,6 @@ REQUIRES
 
 ENSURES
 	preparedIV[this];
+WEAKNESSES
+    CWE-330;
+	CWE-323;

--- a/JavaCryptographicArchitecture/src/Key.crysl
+++ b/JavaCryptographicArchitecture/src/Key.crysl
@@ -15,3 +15,6 @@ REQUIRES
 	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;
+    
+WEAKNESSES
+    CWE-200;

--- a/JavaCryptographicArchitecture/src/KeyAgreement.crysl
+++ b/JavaCryptographicArchitecture/src/KeyAgreement.crysl
@@ -49,3 +49,10 @@ REQUIRES
     
 ENSURES
 	preparedKeyMaterial[sharedSecretBuffer] after GenSecretBuffer;
+	
+WEAKNESSES
+    CWE-320;
+    CWE-325;
+    CWE-327;
+    CWE-330;
+    CWE-338;

--- a/JavaCryptographicArchitecture/src/KeyFactory.crysl
+++ b/JavaCryptographicArchitecture/src/KeyFactory.crysl
@@ -30,3 +30,7 @@ ENSURES
 	generatedKeyFactory[this, algorithm] after Get;
 	generatedPrivkey[privateKey] after GenPriv;
 	generatedPubkey[publicKey] after GenPubl;
+
+WEAKNESSES
+    CWE-327;
+	CWE-326;

--- a/JavaCryptographicArchitecture/src/KeyGenerator.crysl
+++ b/JavaCryptographicArchitecture/src/KeyGenerator.crysl
@@ -34,3 +34,8 @@ REQUIRES
     
 ENSURES 
 	generatedKey[key, algorithm];
+
+WEAKNESSES
+    CWE-326;
+    CWE-327;
+    CWE-330;

--- a/JavaCryptographicArchitecture/src/KeyManagerFactory.crysl
+++ b/JavaCryptographicArchitecture/src/KeyManagerFactory.crysl
@@ -34,3 +34,7 @@ REQUIRES
 ENSURES
 	generatedKeyManager[this] after Init;
 	generatedKeyManagers[keyManager] after GetKeyMng;
+
+WEAKNESSES
+    CWE-259;
+	CWE-316;

--- a/JavaCryptographicArchitecture/src/KeyPair.crysl
+++ b/JavaCryptographicArchitecture/src/KeyPair.crysl
@@ -28,3 +28,13 @@ ENSURES
 	generatedKeypair[this, _] after Con;
 	generatedPubkey[retPublicKey] after GetPubl;
 	generatedPrivkey[retPrivateKey] after GetPriv;
+
+WEAKNESSES
+    CWE-320;
+    CWE-321;
+    CWE-330;
+    CWE-331;
+    CWE-338;
+    CWE-325;
+	CWE-326;
+

--- a/JavaCryptographicArchitecture/src/KeyPairGenerator.crysl
+++ b/JavaCryptographicArchitecture/src/KeyPairGenerator.crysl
@@ -39,3 +39,8 @@ REQUIRES
 
 ENSURES
 	generatedKeypair[keyPair, algorithm];
+
+WEAKNESSES
+    CWE-326;
+    CWE-330;
+    CWE-338;

--- a/JavaCryptographicArchitecture/src/KeyStore.crysl
+++ b/JavaCryptographicArchitecture/src/KeyStore.crysl
@@ -60,3 +60,6 @@ ENSURES
 	generatedKey[key, _];
 	generatedPrivkey[key];
 	generatedPubkey[key];
+
+WEAKNESSES
+    CWE-259;

--- a/JavaCryptographicArchitecture/src/KeyStoreBuilderParameters.crysl
+++ b/JavaCryptographicArchitecture/src/KeyStoreBuilderParameters.crysl
@@ -12,3 +12,7 @@ ORDER
 	
 ENSURES
 	generatedManagerFactoryParameters[this];
+
+WEAKNESSES
+    CWE-295;
+	CWE-259;

--- a/JavaCryptographicArchitecture/src/MGF1ParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/MGF1ParameterSpec.crysl
@@ -15,3 +15,7 @@ CONSTRAINTS
 
 ENSURES
 	preparedMGF1[this, mdName];
+
+WEAKNESSES
+    CWE-327;
+	CWE-328;

--- a/JavaCryptographicArchitecture/src/Mac.crysl
+++ b/JavaCryptographicArchitecture/src/Mac.crysl
@@ -57,3 +57,11 @@ ENSURES
 	macced[output1, inputByte];
 	macced[output1, preInput];
 	macced[output2, input];
+
+WEAKNESSES
+    CWE-320;
+    CWE-325;
+    CWE-328;
+    CWE-330;
+	CWE-916;
+	CWE-327;

--- a/JavaCryptographicArchitecture/src/MessageDigest.crysl
+++ b/JavaCryptographicArchitecture/src/MessageDigest.crysl
@@ -46,3 +46,6 @@ ENSURES
 	generatedMessageDigest[this] after Get;
 	digested[output, _];
 	digested[output, input];
+
+WEAKNESSES
+    CWE-327;

--- a/JavaCryptographicArchitecture/src/OAEPParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/OAEPParameterSpec.crysl
@@ -22,3 +22,7 @@ REQUIRES
 
 ENSURES
 	preparedOAEP[this];
+
+WEAKNESSES
+    CWE-327;
+    CWE-328;

--- a/JavaCryptographicArchitecture/src/PBEKeySpec.crysl
+++ b/JavaCryptographicArchitecture/src/PBEKeySpec.crysl
@@ -33,3 +33,13 @@ ENSURES
 
 NEGATES
 	speccedKey[this, _] after ClearPass;
+
+WEAKNESSES
+    CWE-259;
+    CWE-326;
+    CWE-330;
+    CWE-760;
+	CWE-916;
+	CWE-760;
+	CWE-750;
+	CWE-226;

--- a/JavaCryptographicArchitecture/src/PBEParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/PBEParameterSpec.crysl
@@ -21,3 +21,9 @@ REQUIRES
 			
 ENSURES
 	preparedPBE[this];
+
+WEAKNESSES
+    CWE-330;
+    CWE-916;
+    CWE-331;
+	CWE-760;

--- a/JavaCryptographicArchitecture/src/PKIXBuilderParameters.crysl
+++ b/JavaCryptographicArchitecture/src/PKIXBuilderParameters.crysl
@@ -19,3 +19,6 @@ REQUIRES
 	
 ENSURES
 	generatedCertPathParameters[this];
+WEAKNESSES
+    CWE-295;
+ 

--- a/JavaCryptographicArchitecture/src/PKIXParameters.crysl
+++ b/JavaCryptographicArchitecture/src/PKIXParameters.crysl
@@ -16,3 +16,6 @@ REQUIRES
 
 ENSURES
 	generatedCertPathParameters[this];
+	
+WEAKNESSES
+    CWE-295;

--- a/JavaCryptographicArchitecture/src/PasswordAuthentication.crysl
+++ b/JavaCryptographicArchitecture/src/PasswordAuthentication.crysl
@@ -24,3 +24,7 @@ CONSTRAINTS
 	
 ENSURES
 	generatedPasswordAuthentication[this];
+
+WEAKNESSES
+    CWE-259;
+	CWE-798;

--- a/JavaCryptographicArchitecture/src/PrivateKey.crysl
+++ b/JavaCryptographicArchitecture/src/PrivateKey.crysl
@@ -15,3 +15,10 @@ REQUIRES
 	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;
+
+WEAKNESSES
+    CWE-312;
+    CWE-319;
+    CWE-320;
+    CWE-321;
+    CWE-326;

--- a/JavaCryptographicArchitecture/src/PublicKey.crysl
+++ b/JavaCryptographicArchitecture/src/PublicKey.crysl
@@ -15,3 +15,9 @@ REQUIRES
 	
 ENSURES
 	preparedKeyMaterial[keyMaterial] after GetEnc;
+WEAKNESSES
+    CWE-295;
+    CWE-347;
+	CWE-326;
+	CWE-328;
+	CWE-345;

--- a/JavaCryptographicArchitecture/src/RSAKeyGenParameterSpec.crysl
+++ b/JavaCryptographicArchitecture/src/RSAKeyGenParameterSpec.crysl
@@ -17,3 +17,6 @@ CONSTRAINTS
 	 
 ENSURES
 	preparedRSA[this];
+
+WEAKNESSES
+    CWE-326;

--- a/JavaCryptographicArchitecture/src/SSLContext.crysl
+++ b/JavaCryptographicArchitecture/src/SSLContext.crysl
@@ -36,3 +36,9 @@ REQUIRES
 ENSURES
 	generatedSSLContext[this] after Init;
 	generatedSSLEngine[eng] after Engine;
+
+WEAKNESSES
+    CWE-295;
+    CWE-321;
+    CWE-327;
+    CWE-330;

--- a/JavaCryptographicArchitecture/src/SSLEngine.crysl
+++ b/JavaCryptographicArchitecture/src/SSLEngine.crysl
@@ -34,3 +34,8 @@ CONSTRAINTS
 		
 ENSURES
 	generatedSSLEngine[this];
+
+WEAKNESSES
+    CWE-326;
+    CWE-327;
+	cw-757;

--- a/JavaCryptographicArchitecture/src/SSLParameters.crysl
+++ b/JavaCryptographicArchitecture/src/SSLParameters.crysl
@@ -36,3 +36,8 @@ CONSTRAINTS
 				
 ENSURES
 	generatedSSLParameters[this];
+
+WEAKNESSES
+    CWE-326;
+    CWE-327;
+	CWE-757;

--- a/JavaCryptographicArchitecture/src/SecretKey.crysl
+++ b/JavaCryptographicArchitecture/src/SecretKey.crysl
@@ -21,3 +21,8 @@ ENSURES
 
 NEGATES
 	generatedKey[this, _] after Destroy;
+
+WEAKNESSES
+    CWE-320;
+    CWE-321;
+	CWE-226;

--- a/JavaCryptographicArchitecture/src/SecretKeyFactory.crysl
+++ b/JavaCryptographicArchitecture/src/SecretKeyFactory.crysl
@@ -29,3 +29,10 @@ REQUIRES
 	
 ENSURES
 	generatedKey[key, algorithm];
+
+WEAKNESSES
+    CWE-320;
+    CWE-327;
+    CWE-330;
+    CWE-326;
+    CWE-916;

--- a/JavaCryptographicArchitecture/src/SecretKeySpec.crysl
+++ b/JavaCryptographicArchitecture/src/SecretKeySpec.crysl
@@ -25,3 +25,10 @@ REQUIRES
 ENSURES
 	speccedKey[this, _];
 	generatedKey[this, keyAlgorithm];
+
+WEAKNESSES
+    CWE-325;
+    CWE-326;
+    CWE-327;
+    CWE-330;
+	CWE-321;

--- a/JavaCryptographicArchitecture/src/SecureRandom.crysl
+++ b/JavaCryptographicArchitecture/src/SecureRandom.crysl
@@ -51,3 +51,10 @@ ENSURES
 	randomized[bytes] after nB;
 	randomized[randInt] after nI;
 	randomized[randIntInRange] after nIR;
+
+WEAKNESSES
+    CWE-330;
+    CWE-338;
+	CWE-335;
+	CWE-337;
+	CWE-331;

--- a/JavaCryptographicArchitecture/src/Signature.crysl
+++ b/JavaCryptographicArchitecture/src/Signature.crysl
@@ -59,3 +59,13 @@ ENSURES
 	signed[output, input] after Sign;
 	signed[output, inputByteBuffer] after Sign;
 	verified[verified, sign] after Verify;
+
+WEAKNESSES
+    CWE-284;
+    CWE-295;
+    CWE-326;
+    CWE-327;
+    CWE-330;
+    CWE-347;
+    CWE-325;
+

--- a/JavaCryptographicArchitecture/src/TrustAnchor.crysl
+++ b/JavaCryptographicArchitecture/src/TrustAnchor.crysl
@@ -19,3 +19,6 @@ REQUIRES
 	
 ENSURES
 	generatedTrustAnchor[this];
+	
+WEAKNESSES
+    CWE-295;

--- a/JavaCryptographicArchitecture/src/TrustManagerFactory.crysl
+++ b/JavaCryptographicArchitecture/src/TrustManagerFactory.crysl
@@ -31,3 +31,8 @@ REQUIRES
 ENSURES
 	generatedTrustManager[this] after Init;			
 	generatedTrustManagers[trustManager] after GetTrustMng;
+
+WEAKNESSES
+    CWE-295;
+    CWE-322;
+    CWE-326;

--- a/JavaCryptographicArchitecture/src/X509EncodedKeySpec.crysl
+++ b/JavaCryptographicArchitecture/src/X509EncodedKeySpec.crysl
@@ -15,3 +15,8 @@ REQUIRES
  	
 ENSURES
 	speccedKey[this, _] after Con;
+
+WEAKNESSES
+    CWE-330;
+    CWE-326;
+    CWE-345;


### PR DESCRIPTION
This PR updates CrySL rules with CWE IDs.

Note: The CWE–CrySL mapping might still contain some mismatches. Further refinement may be necessary in future iterations.