### PR TITLE
Make SecretKeySpec accept randomized key material

### DIFF
--- a/BouncyCastle-JCA/src/SecretKeySpec.crysl
+++ b/BouncyCastle-JCA/src/SecretKeySpec.crysl
@@ -21,7 +21,7 @@ CONSTRAINTS
 	neverTypeOf[keyMaterial, java.lang.String];
 	
 REQUIRES
-	preparedKeyMaterial[keyMaterial];	
+	preparedKeyMaterial[keyMaterial] || randomized[keyMaterial];	
 	
 ENSURES
 	speccedKey[this, _];

--- a/JavaCryptographicArchitecture/src/SecretKeySpec.crysl
+++ b/JavaCryptographicArchitecture/src/SecretKeySpec.crysl
@@ -20,7 +20,7 @@ CONSTRAINTS
 	neverTypeOf[keyMaterial, java.lang.String];
 	
 REQUIRES
-	preparedKeyMaterial[keyMaterial];	
+	preparedKeyMaterial[keyMaterial] || randomized[keyMaterial];	
 	
 ENSURES
 	speccedKey[this, _];


### PR DESCRIPTION
SecretKeySpec requires "preparedKeyMaterial[keyMaterial]", but SecureRandom ensures "randomized" and not "preparedKeyMaterial".

This commit extends the predicate in the "REQUIRES" section of SecretKeySpec by `|| randomized[keyMaterial]` to make it also accept randomized key material.